### PR TITLE
소셜로그인 플로우 개선

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,10 @@
 import axios from "axios";
-import type { AuthTokens, User } from "@types";
+import type {
+	AuthTokens,
+	Provider,
+	SocialLoginRequestBody,
+	User,
+} from "@types";
 import api, { API_URL } from "./axios";
 import { TokenService } from "./tokenService";
 
@@ -39,15 +44,29 @@ export const login = async (email: string, password: string) => {
 };
 
 export const socialLogin = async (
-	provider: string,
+	provider: Provider,
 	code: string,
 	codeVerifier?: string,
 ) => {
-	const res = await api.post<AuthTokens>("/auth/login/social", {
-		provider,
-		code,
-		codeVerifier,
-	});
+	TokenService.clearTokens();
+
+	let body: SocialLoginRequestBody;
+	if (provider === "GOOGLE") {
+		if (!codeVerifier) {
+			throw new Error("codeVerifier is required for Google login");
+		}
+		body = {
+			provider: "GOOGLE",
+			code,
+			codeVerifier,
+		};
+	} else {
+		body = {
+			provider,
+			code,
+		};
+	}
+	const res = await api.post<AuthTokens>("/auth/login/social", body);
 	TokenService.setTokens(res.data.accessToken, res.data.refreshToken);
 };
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -49,7 +49,7 @@ api.interceptors.response.use(
 			url.includes("/auth/login") ||
 			url.includes("/auth/register") ||
 			url.includes("/auth/refresh");
-			
+
 		if (isAuthApi) {
 			return Promise.reject(error);
 		}

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -6,7 +6,8 @@ import {
 	useState,
 } from "react";
 import * as auth from "@api/auth";
-import type { User } from "@types";
+import type { Provider, User } from "@types";
+import { TokenService } from "@/api/tokenService";
 
 interface AuthContextType {
 	user: User | null;
@@ -15,7 +16,7 @@ interface AuthContextType {
 	login: (email: string, password: string) => Promise<void>;
 	signup: (email: string, password: string) => Promise<void>;
 	socialLogin: (
-		provider: string,
+		provider: Provider,
 		code: string,
 		codeVerifier?: string,
 	) => Promise<void>;
@@ -70,12 +71,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	};
 
 	const socialLogin = async (
-		provider: string,
+		provider: Provider,
 		code: string,
 		codeVerifier?: string,
 	) => {
 		try {
 			await auth.socialLogin(provider, code, codeVerifier);
+			if (!TokenService.getAccessToken()) {
+				throw new Error("Social login did not set access token");
+			}
 			const userData = await auth.getUser();
 			setUser(userData);
 			setIsAuthenticated(true);

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -285,3 +285,20 @@ export interface ApiErrorResponse {
 	code: string;
 	message: string;
 }
+
+export type Provider = "GOOGLE" | "KAKAO" | "NAVER";
+
+export type GoogleSocialLoginBody = {
+	provider: "GOOGLE";
+	code: string;
+	codeVerifier: string;
+};
+
+export type OtherSocialLoginBody = {
+	provider: "KAKAO" | "NAVER";
+	code: string;
+};
+
+export type SocialLoginRequestBody =
+	| GoogleSocialLoginBody
+	| OtherSocialLoginBody;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 다른 계정으로 소셜로그인 시도 -> 기존 토큰 clear 하고 로그인
- social login request body에서 구글 로그인일 경우만 codeVerifer 포함하는 것으로 규칙 강화
- provider 유니언 타입, Social Login Request Body type 추가
- 소셜로그인 성공 후에만 getUser 호출

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
