### PR TITLE
feat: implement memo and tag UI logic without backend integration

### DIFF
--- a/src/styles/DetailView.module.css
+++ b/src/styles/DetailView.module.css
@@ -128,13 +128,233 @@
 	margin-bottom: 40px;
 }
 
+/* ===== Memo / Tag UI ===== */
+
 .memo {
 	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 10px;
+
+	margin-top: auto;
+	padding: 12px 12px 14px;
+	border: 1px solid #eeeeee;
+	border-radius: 14px;
+	background: #ffffff;
+
+	color: #333333;
+}
+
+.memo:focus-within {
+	border-color: #d9d9d9;
+}
+
+.memoHeader {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.memoIconBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+
+	width: 28px;
+	height: 28px;
+	border-radius: 8px;
+
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+}
+
+.memoIconBtn:hover {
+	background: #f6f6f6;
+}
+
+.memoTriggerText {
+	background: transparent;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+
+	color: #828282;
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.memoSaveBtn {
+	margin-left: auto;
+
+	background: transparent;
+	border: none;
+	padding: 0;
+	cursor: pointer;
+
+	color: #828282;
+	font-size: 13px;
+	font-weight: 500;
+	white-space: nowrap;
+}
+
+.memoSaveBtn:disabled {
+	cursor: default;
+	opacity: 0.6;
+}
+
+.memoBody {
+	width: 100%;
+}
+
+.memoInput {
+	width: 100%;
+	box-sizing: border-box;
+
+	border: 1px solid #e9e9e9;
+	border-radius: 12px;
+	padding: 10px 12px;
+
+	font-size: 13px;
+	line-height: 1.5;
+	color: #111111;
+	outline: none;
+
+	background: #ffffff;
+}
+
+.memoInput::placeholder {
+	color: #b0b0b0;
+}
+
+.memoInput:focus {
+	border-color: #d9d9d9;
+}
+
+.memoInput:disabled {
+	background: #fafafa;
+	color: #777777;
+}
+
+/* textarea 전용 보정 */
+textarea.memoInput {
+	resize: none;
+	min-height: 92px;
+}
+
+/* ---- Tag Section ---- */
+
+.tagSection {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.tagRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.tagInput {
+	flex: 1;
+	box-sizing: border-box;
+
+	border: 1px solid #e9e9e9;
+	border-radius: 12px;
+	padding: 10px 12px;
+
+	font-size: 13px;
+	line-height: 1.4;
+	outline: none;
+}
+
+.tagInput::placeholder {
+	color: #b0b0b0;
+}
+
+.tagInput:focus {
+	border-color: #d9d9d9;
+}
+
+.tagAddBtn {
+	border: 1px solid #e9e9e9;
+	border-radius: 12px;
+	padding: 10px 12px;
+
+	font-size: 13px;
+	font-weight: 500;
+	background: #ffffff;
+	cursor: pointer;
+	white-space: nowrap;
+}
+
+.tagAddBtn:hover:not(:disabled) {
+	background: #f7f7f7;
+}
+
+.tagAddBtn:disabled {
+	cursor: default;
+	opacity: 0.6;
+}
+
+/* chips */
+.tagChips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.tagChip {
+	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	margin-top: auto;
+
+	padding: 7px 10px;
+	border-radius: 999px;
+	border: 1px solid #e9e9e9;
+	background: #fafafa;
+
+	font-size: 12px;
+	color: #333333;
+}
+
+.tagChipText {
+	line-height: 1;
+}
+
+.tagChipRemove {
+	border: none;
+	background: transparent;
 	cursor: pointer;
-	color: #828282;
+
+	width: 18px;
+	height: 18px;
+	border-radius: 6px;
+
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+
+	color: #777777;
 	font-size: 14px;
-	font-weight: 500;
+	line-height: 1;
+	padding: 0;
+}
+
+.tagChipRemove:hover {
+	background: #eeeeee;
+}
+
+/* helper / error */
+.helperText {
+	font-size: 12px;
+	color: #8a8a8a;
+}
+
+.errorText {
+	margin-top: 2px;
+	font-size: 12px;
+	color: #dc3c3c;
 }

--- a/src/widgets/DetailView.tsx
+++ b/src/widgets/DetailView.tsx
@@ -1,6 +1,6 @@
 import { addBookmark, removeBookmark } from "@api/user";
 import { useEvents } from "@contexts/EventContext";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import styles from "@styles/DetailView.module.css";
 import { formatDateDotParsed } from "@calendarUtil/dateFormatter";
 import { getDDay } from "../util/Calendar/getDday";
@@ -11,6 +11,9 @@ import type { EventDetail } from "@types";
 import DOMPurify from "isomorphic-dompurify";
 import parse from "html-react-parser";
 
+// ✅ TODO: 연동
+// import { useUserData } from "@contexts/UserDataContext";
+
 const DetailView = ({
 	eventId,
 	onClose,
@@ -20,6 +23,9 @@ const DetailView = ({
 }) => {
 	const [event, setEvent] = useState<EventDetail>();
 	const { fetchEventById } = useEvents();
+
+	// ✅ TODO: useUserData()에서 함수 가져와서 쓰기
+	// const { createMemo, createTag, deleteTag } = useUserData();
 
 	useEffect(() => {
 		const loadEvent = async () => {
@@ -38,11 +44,44 @@ const DetailView = ({
 		!!event?.isBookmarked,
 	);
 
+	// 메모 관련 상태
+	const [memo, setMemo] = useState<string>("");
+	const [isSavingMemo, setIsSavingMemo] = useState<boolean>(false);
+	const [memoError, setMemoError] = useState<string | null>(null);
+	const [isMemoExpanded, setIsMemoExpanded] = useState<boolean>(false);
+
+	// 태그 관련 상태
+	const [tagNames, setTagNames] = useState<string[]>([]);
+	const [tagInput, setTagInput] = useState<string>("");
+	const [isSavingTag, setIsSavingTag] = useState(false);
+	const [tagError, setTagError] = useState<string | null>(null);
+
+	// 메모 & 태그 input ref
+	const memoInputRef = useRef<HTMLTextAreaElement | null>(null);
+	const tagInputRef = useRef<HTMLInputElement | null>(null);
+
+	// 태그 관련 함수
+	const normalizeTag = (raw: string) => {
+		// 공백 제거, # 제거, 연속 공백 정리
+		const tag = raw.trim().replace(/^#+/, "");
+		return tag;
+	};
 	useEffect(() => {
 		if (event) {
 			setIsBookmarked(event.isBookmarked ? event.isBookmarked : false);
 		}
 	}, [event]);
+
+	useEffect(() => {
+		void eventId;
+
+		setMemo("");
+		setTagInput("");
+		setTagNames([]);
+		setMemoError(null);
+		setIsSavingMemo(false);
+		setIsMemoExpanded(false);
+	}, [eventId]);
 
 	if (!event) return null;
 
@@ -63,6 +102,79 @@ const DetailView = ({
 			setIsBookmarked(previousState);
 		}
 	};
+
+	// 메모 입력 영역 확장 함수
+	const expandMemo = () => {
+		if (!isMemoExpanded) setIsMemoExpanded(true);
+		// 다음 tick에 포커스
+		setTimeout(() => memoInputRef.current?.focus(), 0);
+	};
+
+	// 태그 추가
+	const addTag = (raw?: string) => {
+		const candidate = normalizeTag(raw ?? tagInput);
+		if (!candidate) return;
+
+		setTagNames((prev) => {
+			// 대소문자 무시, 중복 방지
+			const exists = prev.some(
+				(t) => t.toLowerCase() === candidate.toLowerCase(),
+			);
+			if (exists) return prev;
+			return [...prev, candidate];
+		});
+		setTagInput("");
+		setMemoError(null);
+		// 태그 추가 후 계속 입력할 수 있게 유지
+		setTimeout(() => tagInputRef.current?.focus(), 0);
+	};
+
+	// 태그 삭제
+	const removeTag = (tag: string) => {
+		setTagNames((prev) => prev.filter((t) => t !== tag));
+	};
+
+	// 메모 저장 기능
+	const handleMemoSave = async () => {
+		setMemoError(null);
+
+		const content = memo.trim();
+		if (!content) {
+			setMemoError("메모 내용을 입력해주세요.");
+			return;
+		}
+
+		setIsSavingMemo(true);
+		try {
+			// ✅ TODO: api 연동 (메모 저장)
+			// await createMemo(eventId, content, tagNames);
+
+			// ✅ TODO: api 연동 (태그를 하나씩 저장)
+			// const failed: string[] = [];
+			// for (const tag of tagNames) {
+			//   try {
+			//     await createTag(eventId, tag);
+			//   } catch (e) {
+			//     console.error("Tag create failed:", tag, e);
+			//     failed.push(tag);
+			//   }
+			// }
+			// if (failed.length > 0) {
+			//   setTagError?.(`${failed.join(", ")} 태그 저장에 실패했어요.`);
+			// }
+
+			setMemo("");
+			setTagNames([]);
+		} catch (error) {
+			console.error("메모 저장 실패:", error);
+			setMemoError("메모 저장에 실패했습니다. 다시 시도해주세요.");
+		} finally {
+			setIsSavingMemo(false);
+		}
+	};
+
+	// 메모 저장 가능 여부 판단
+	// const canSaveMemo = useMemo(() => memo.trim().length > 0 && !isSavingMemo, [memo, isSavingMemo]);
 
 	return (
 		<div className={styles.container}>
@@ -132,9 +244,139 @@ const DetailView = ({
 				<hr style={{ borderWidth: "0.5px" }} />
 				{parse(DOMPurify.sanitize(event.detail))}
 			</div>
+			{/* ----- Memo & Tag Section ----- */}
 			<div className={styles.memo}>
-				<TiPencil width={18} color="rgba(130, 130, 130, 1)" />
-				<span>메모하기</span>
+				{/* 헤더 라인 (연필/메모하기/저장하기) */}
+				<div className={styles.memoHeader}>
+					<button
+						type="button"
+						onClick={expandMemo}
+						className={styles.memoIconBtn}
+						aria-label="메모 입력 열기"
+					>
+						<TiPencil width={18} color="rgba(130, 130, 130, 1)" />
+					</button>
+
+					{memo.trim().length > 0 ? (
+						<button
+							type="button"
+							onClick={(e) => {
+								e.stopPropagation();
+								handleMemoSave();
+							}}
+							className={styles.memoSaveBtn}
+							disabled={isSavingMemo}
+						>
+							{isSavingMemo ? "저장 중..." : "저장하기"}
+						</button>
+					) : (
+						<button
+							type="button"
+							onClick={expandMemo}
+							className={styles.memoTriggerText}
+						>
+							메모하기
+						</button>
+					)}
+				</div>
+
+				{/* 메모 입력 */}
+				<div className={styles.memoBody}>
+					{isMemoExpanded ? (
+						<textarea
+							ref={memoInputRef}
+							value={memo}
+							onChange={(e) => {
+								setMemo(e.target.value);
+								setMemoError(null);
+							}}
+							disabled={isSavingMemo}
+							className={styles.memoInput}
+							placeholder="메모를 입력하세요"
+							rows={4}
+						/>
+					) : (
+						<input
+							value={memo}
+							onChange={(e) => {
+								setMemo(e.target.value);
+								setMemoError(null);
+							}}
+							className={styles.memoInput}
+							type="text"
+							placeholder="메모를 입력하세요"
+							disabled={isSavingMemo}
+							onFocus={expandMemo}
+							onClick={(e) => {
+								e.stopPropagation();
+								expandMemo();
+							}}
+						/>
+					)}
+				</div>
+
+				{/* 태그 영역: 확장 시만 노출 */}
+				{isMemoExpanded ? (
+					<div className={styles.tagSection} role="presentation">
+						<div className={styles.tagRow}>
+							<input
+								ref={tagInputRef}
+								value={tagInput}
+								onChange={(e) => setTagInput(e.target.value)}
+								placeholder="태그 추가…"
+								type="text"
+								className={styles.tagInput}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										if (!isSavingTag) addTag();
+									}
+									if (
+										e.key === "Backspace" &&
+										tagInput.length === 0 &&
+										tagNames.length > 0
+									) {
+										removeTag(tagNames[tagNames.length - 1]);
+									}
+								}}
+							/>
+
+							<button
+								type="button"
+								onClick={() => addTag()}
+								className={styles.tagAddBtn}
+								disabled={isSavingTag || normalizeTag(tagInput).length === 0}
+							>
+								추가
+							</button>
+						</div>
+
+						{tagNames.length > 0 ? (
+							<div className={styles.tagChips}>
+								{tagNames.map((t) => (
+									<span key={t} className={styles.tagChip}>
+										<span className={styles.tagChipText}>#{t}</span>
+										<button
+											type="button"
+											onClick={() => removeTag(t)}
+											className={styles.tagChipRemove}
+											aria-label={`remove tag ${t}`}
+										>
+											×
+										</button>
+									</span>
+								))}
+							</div>
+						) : (
+							<div className={styles.helperText}>
+								Enter 또는 “추가”로 태그를 추가할 수 있어요.
+							</div>
+						)}
+					</div>
+				) : null}
+
+				{memoError ? <div className={styles.errorText}>{memoError}</div> : null}
+				{tagError ? <div className={styles.errorText}>{tagError}</div> : null}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 상세 뷰에서 메모, 태그 추가 UI 로직 구현

## ✅ 체크리스트
- ✅ 로컬에서 정상 동작 확인
- ✅ 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
