### PR TITLE
온보딩 이후 관심 카테고리 반영 안되는 이슈 수정

### DIFF
--- a/src/pages/auth/OnBoarding/Onboarding.tsx
+++ b/src/pages/auth/OnBoarding/Onboarding.tsx
@@ -73,9 +73,9 @@ export default function Onboarding({
 			}));
 
 			await addInterestCategories(items);
+			refreshUserData();
 
 			if (isEditing && onFinishEdit) {
-				refreshUserData();
 				onFinishEdit();
 			}
 			setSearchParams((prev) => {

--- a/src/styles/MyPage.module.css
+++ b/src/styles/MyPage.module.css
@@ -194,6 +194,7 @@
 .preferenceChips {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 8px;
 	list-style: none;

--- a/src/widgets/Week/CustomWeekView.tsx
+++ b/src/widgets/Week/CustomWeekView.tsx
@@ -58,10 +58,6 @@ function useAnchorRect<T extends HTMLElement>(
 	return rect;
 }
 
-// function isValidPeriodEvent(ev: Event): ev is PeriodEvent {
-// 	return ev.applyStart instanceof Date && ev.applyEnd instanceof Date;
-// }
-
 function CustomWeekView({
 	date,
 	localizer,
@@ -79,9 +75,9 @@ function CustomWeekView({
 
 		return events
 			.filter((cevent: CalendarEvent) => {
+				console.log("Filtering event:", cevent, cevent.start, cevent.end);
 				const eventStart = cevent.start;
 				const eventEnd = cevent.end;
-				console.log("filtering events", { cevent, eventStart, eventEnd});
 
 				return eventStart <= weekEnd && eventEnd >= weekStart;
 			})
@@ -102,7 +98,10 @@ function CustomWeekView({
 						cevent.end.getMonth(),
 						cevent.end.getDate(),
 					);
-					const differentDate = startDay.getTime() !== endDay.getTime();
+					const differentDate = (startDay.getFullYear() !== endDay.getFullYear() 
+						&& startDay.getMonth() !== endDay.getMonth() 
+						&& startDay.getDate() !== endDay.getDate());
+					
 					isAllDay = Boolean(cevent.allDay) || differentDate || sameMinute;
 				}
 

--- a/src/widgets/Week/CustomWeekView.tsx
+++ b/src/widgets/Week/CustomWeekView.tsx
@@ -81,6 +81,7 @@ function CustomWeekView({
 			.filter((cevent: CalendarEvent) => {
 				const eventStart = cevent.start;
 				const eventEnd = cevent.end;
+				console.log("filtering events", { cevent, eventStart, eventEnd});
 
 				return eventStart <= weekEnd && eventEnd >= weekStart;
 			})

--- a/src/widgets/Week/PeriodBar.tsx
+++ b/src/widgets/Week/PeriodBar.tsx
@@ -86,7 +86,6 @@ export function PeriodBars({
 	bottomOffset = 8,
 	onSelectEvent,
 }: Props) {
-	console.log("render PeriodBars", { date, items, left, width });
 	const weekStart = useMemo(() => startOfWeekSunday(date), [date]);
 	const weekEnd = useMemo(() => endOfWeekSaturday(date), [date]);
 
@@ -151,7 +150,6 @@ export function PeriodBars({
 
 				const categoryId = b.raw.resource.event.eventTypeId;
 				const color = CATEGORY_COLORS[categoryId] ?? "#999";
-				console.log("color", { categoryId, color });
 
 				const style: CSSVarStyle = {
 					left: `${leftPct}px`,


### PR DESCRIPTION
## 📝 작업 내용

온보딩 이후 userData를 refresh하는 로직 추가
마이페이지 관심 카테고리 overflow issue 해결

## ✅ 체크리스트
- [✅] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [✅] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)
이전
<img width="1090" height="455" alt="스크린샷 2026-04-14 235941" src="https://github.com/user-attachments/assets/c304b4b8-7ff5-4022-b6ab-e848ed1d3dca" />

이후
<img width="464" height="107" alt="image" src="https://github.com/user-attachments/assets/fcd9d5a2-eebc-40ae-b3fa-bc3244f0858e" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
