### PR TITLE
모바일 캘린더 뷰 이벤트 클릭 및 블록 이벤트 미리보기 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
+		"devM": "vite --host",
 		"build": "tsc -b && vite build",
 		"lint": "biome lint .",
 		"preview": "vite preview",

--- a/src/contexts/FilterContext.tsx
+++ b/src/contexts/FilterContext.tsx
@@ -43,12 +43,12 @@ export const FilterContextProvider = ({
 	>([]);
 	// 모집중
 	const isApplying: Category = 
-		categoryGroups.find((g) => g.group.id===1)?.categories.find(c => c.id === 1) 
+		categoryGroups.find((g) => g.group.id===1)?.categories.find(c => c.id === 2) 
 		|| {
-          "id": 1,
+          "id": 2,
           "groupId": 1,
           "name": "모집중",
-          "sortOrder": 1
+          "sortOrder": 2,
         };
 	const [organizations, setOrganizations] = useState<Category[]>([]);
 	const [isLoadingMeta, setIsLoadingMeta] = useState(false);

--- a/src/styles/Calendar.module.css
+++ b/src/styles/Calendar.module.css
@@ -1,6 +1,8 @@
 .main {
-  height: calc(100vh - 3rem);
+  /* height: calc(100vh - 3rem); */
+  min-height: 100dvh;
   padding: 1.5rem;
+  padding-bottom: calc(2rem + env(safe-area-inset-bottom));
 
   background-color: #ffffff;
   font-family:
@@ -12,12 +14,7 @@
     sans-serif;
   /* display: flex;
   flex-direction: column; */
-}
-
-@media (max-width: 576px) {
-  .main {
-    padding: 0.8rem;
-  }
+  margin-bottom: min(50px, 15vh); /* nav bar + a*/
 }
 
 :global(.rbc-calendar) {
@@ -68,7 +65,7 @@
 }
 
 :global(.rbc-month-row):last-child {
-  border-bottom: none;
+  border-bottom: 0;
 }
 
 /* Background grid layer */
@@ -193,7 +190,22 @@
 
 @media (max-width: 576px) {
   :global(.rbc-day-bg) {
-    border-left: 2.5px solid #ffffff;
-    border-radius: 5px;
+    border: 1px solid #ffffff;
+    border-radius: 3px;
+  }
+  :global(.rbc-event-content) {
+    padding: 0;
+  }
+  :global(.rbc-month-row) {
+    min-height: 110px;
+    border: 0.5px solid #ffffff;
+  }
+
+  .main {
+    padding-left: 0px;
+    padding-right: 0px;
+    padding-bottom: calc(2rem + env(safe-area-inset-bottom));
+    touch-action: pan-y; /* drop horizontal finger drag */
+    overscroll-behavior-x: none; /* block horizontal overscroll chaining */
   }
 }

--- a/src/styles/CalendarView.module.css
+++ b/src/styles/CalendarView.module.css
@@ -2,13 +2,18 @@ body {
   overflow: hidden;
   padding: 0;
   margin: 0;
+  overscroll-behavior: none;
+
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .container {
   display: flex;
   flex-direction: row;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   background-color: #ffffff;
   padding: 0;
@@ -26,9 +31,10 @@ body {
 .calendarWrapper {
   flex: 1;
   height: 100%;
-  padding: 0 20px 200px 20px;
+  padding: 0 20px 0px 20px;
   box-sizing: border-box;
   overflow-y: auto;
+  overscroll-behavior-y: none;
   transition: flex-basis 0.3s ease;
   min-width: 0;
 
@@ -50,7 +56,7 @@ body {
   border-left: 1px solid #e0e0e0;
   background-color: #ffffff;
   box-shadow: -4px 0 24px rgba(0, 0, 0, 0.05);
-  z-index: 100;
+  z-index: 110;
   overflow-y: auto;
   flex-shrink: 0;
   animation: slideIn 0.3s ease-out;
@@ -94,7 +100,7 @@ body {
     width: 340px;
   }
   .calendarWrapper {
-    padding: 0 0px 200px 0px;
+    padding: 0;
   }
 }
 

--- a/src/styles/DetailView.module.css
+++ b/src/styles/DetailView.module.css
@@ -29,7 +29,7 @@
   cursor: pointer;
   align-self: flex-start;
   margin-bottom: 10px;
-  padding: 5px;
+  padding: 10px;
   display: flex;
 }
 

--- a/src/styles/DetailView.module.css
+++ b/src/styles/DetailView.module.css
@@ -29,6 +29,7 @@
   cursor: pointer;
   align-self: flex-start;
   margin-bottom: 10px;
+  padding: 5px;
   display: flex;
 }
 
@@ -119,4 +120,9 @@
   color: #333333;
   white-space: pre-wrap;
   margin-bottom: 40px;
+}
+.contentText :global(img) {
+  max-width: 100%;
+  height: auto;
+  display: block;
 }

--- a/src/styles/DetailView.module.css
+++ b/src/styles/DetailView.module.css
@@ -122,7 +122,8 @@
   margin-bottom: 40px;
 }
 .contentText :global(img) {
-  max-width: 100%;
-  height: auto;
-  display: block;
+  max-width: 100% !important;
+  width: auto !important;
+  height: auto !important;
+  display: block !important;
 }

--- a/src/styles/MonthEvent.module.css
+++ b/src/styles/MonthEvent.module.css
@@ -21,12 +21,44 @@
   transition: all 0.2s ease;
 }
 
-.blockEventContainer:hover {
-  min-width: fit-content;
-  font-size: 0.85rem;
+@media (hover: hover) and (pointer: fine) {
+  .blockEventContainer:hover {
+    min-width: fit-content;
+    font-size: 0.85rem;
+    z-index: 1000;
+    position: relative;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .blockEventContainer {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+    touch-action: none;
+  }
+}
+
+.preview {
+  position: fixed;
+  padding: 8px 12px;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: #1f2937;
+  max-width: calc(100vw - 32px);
+  word-break: keep-all;
+  white-space: normal;
+  text-align: center;
+  pointer-events: none;
   z-index: 1000;
-  position: relative;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition:
+    top 0.15s ease,
+    left 0.15s ease,
+    transform 0.15s ease;
 }
 
 .arrowEventContainer {
@@ -96,4 +128,26 @@
   border-right-style: solid;
   left: -4px;
   bottom: -4px;
+}
+
+@media (max-width: 576px) {
+  .arrowText {
+    font-size: 0.65rem;
+  }
+  .arrowText:hover {
+    font-size: 0.7rem;
+  }
+
+  .blockEventContainer {
+    padding: 2.5px 2px;
+    border-radius: 3px;
+    font-size: 0.65rem;
+    text-overflow: clip;
+  }
+}
+
+@media (max-width: 576px) and (hover: hover) and (pointer: fine) {
+  .blockEventContainer:hover {
+    font-size: 0.7rem;
+  }
 }

--- a/src/styles/MonthSideView.module.css
+++ b/src/styles/MonthSideView.module.css
@@ -1,93 +1,152 @@
 .mainWrapper {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
-	height: 100%;
-	padding: 24px;
-	background-color: #ffffff;
-	box-sizing: border-box;
-	font-family:
-		-apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo",
-		sans-serif;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  background-color: #ffffff;
+  box-sizing: border-box;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo",
+    sans-serif;
 }
 
 .mainWrapper > :global(svg):first-child {
-	margin-bottom: 16px;
-	cursor: pointer;
-	display: block;
+  margin-bottom: 16px;
+  cursor: pointer;
+  display: block;
 }
 
 .dateRow {
-	display: flex;
-	align-items: center;
-	margin-bottom: 24px; /* Space between header and first card */
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px; /* Space between header and first card */
 }
 
 .dateRow h1 {
-	font-size: 28px;
-	font-weight: 700;
-	color: #111111;
-	margin: 0;
-	line-height: 1;
-	letter-spacing: -0.5px;
+  font-size: 28px;
+  font-weight: 700;
+  color: #111111;
+  margin: 0;
+  line-height: 1;
+  letter-spacing: -0.5px;
 }
 
-.dateRow button:first-of-type {
-	margin-left: 12px;
-	margin-right: 8px;
+.todayBtn {
+  margin-left: 12px;
+  margin-right: 8px;
 
-	padding: 6px 14px;
-	background-color: #ffffff;
-	border: 1px solid #e0e0e0;
-	border-radius: 20px;
+  padding: 6px 14px;
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 20px;
 
-	font-size: 13px;
-	font-weight: 500;
-	color: #555555;
-	cursor: pointer;
-	transition: background-color 0.2s;
+  font-size: 13px;
+  font-weight: 500;
+  color: #555555;
+  cursor: pointer;
+  transition: background-color 0.2s;
 }
 
-.dateRow button:first-of-type:hover {
-	background-color: #f7f7f7;
+.todayBtn:hover {
+  background-color: #f7f7f7;
 }
 
-.dateRow button:not(:first-of-type) {
-	background: none;
-	border: none;
-	cursor: pointer;
-	padding: 8px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+.dateChangeBtn {
+  width: 36px;
+  height: 36px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.foldBtn {
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+
+  align-self: flex-start;
+  margin-bottom: 10px;
+  padding: 0px;
+  display: flex;
+}
+
+.mobileCloseBtn {
+  width: 40px;
+  height: 40px;
+
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 10px;
+  display: none;
+}
+
+.foldBtn svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.dateChangeBtn svg {
+  width: 18px;
+  height: 18px;
 }
 
 .cardButton {
-	background: none;
-	border-width: 0;
+  background: none;
+  border-width: 0;
 
-	padding: 20px;
-	border-radius: 16px;
-	box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.08);
-	box-sizing: border-box;
+  padding: 20px;
+  border-radius: 16px;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
 }
 
 .cardWrapper {
-	display: flex;
-	flex-direction: column;
-	gap: 16px; /* Vertical space between cards */
+  display: flex;
+  flex-direction: column;
+  gap: 16px; /* Vertical space between cards */
 
-	/* Scroll handling */
-	flex: 1;
-	overflow-y: auto;
-	padding: 4px;
+  /* Scroll handling */
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px;
 }
 
 /*  Hide scrollbar  */
 .cardWrapper::-webkit-scrollbar {
-	width: 0px;
+  width: 0px;
 }
 .cardWrapper::-webkit-scrollbar-thumb {
-	background-color: #e0e0e0;
-	border-radius: 3px;
+  background-color: #e0e0e0;
+  border-radius: 3px;
+}
+
+@media (max-width: 576px) {
+  .foldBtn {
+    display: none;
+  }
+  .mobileCloseBtn {
+    display: flex;
+    margin-left: auto;
+    padding: 0;
+    margin-bottom: 0;
+
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+  }
+  .mobileCloseBtn svg {
+    width: 24px;
+    height: 24px;
+  }
 }

--- a/src/styles/MonthSideView.module.css
+++ b/src/styles/MonthSideView.module.css
@@ -131,6 +131,15 @@
 }
 
 @media (max-width: 576px) {
+  .dateRow h1 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    padding-bottom: 0px;
+  }
+  .todayBtn {
+    padding: 4px 10px;
+    border-radius: 13px;
+  }
   .foldBtn {
     display: none;
   }

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -273,7 +273,7 @@
 
 @media (max-width: 576px) {
   .toolbarContainer {
-    padding-top: 20px;
+    padding-top: 30px;
   }
   .dateTitle {
     font-size: 1.1rem;

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -273,7 +273,7 @@
 
 @media (max-width: 576px) {
   .toolbarContainer {
-    padding-top: 30px;
+    padding-top: 10px;
   }
   .dateTitle {
     font-size: 1.1rem;

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -106,6 +106,7 @@
   font-weight: 700;
   color: #111827;
   margin: 0;
+  padding-left: 5px;
 }
 
 .navBtnGroup {
@@ -273,11 +274,11 @@
 
 @media (max-width: 576px) {
   .toolbarContainer {
-    padding-top: 10px;
+    padding: 10px 10px 0 10px;
   }
   .dateTitle {
     font-size: 1.1rem;
-    font-weight: 500;
+    font-weight: 600;
     padding-bottom: 0px;
   }
   .navIconBtn {

--- a/src/util/Calendar/calendarEventMapper.ts
+++ b/src/util/Calendar/calendarEventMapper.ts
@@ -1,27 +1,26 @@
 import { Views, type View } from "react-big-calendar";
 import type { Event, EventDetail } from "../types";
-import { isLongerThan } from "./isLongerThan";
 
 const calendarEventMapper = (event: Event | EventDetail, currentView: View) => {
-	let isPeriodEvent: boolean;
-	if (!event.eventStart || !event.eventEnd) {
-		// 기본 : eventStart 혹은 eventEnd가 없으면 기간제 행사 처리
-		isPeriodEvent = true;
-	} else if (
-		event.title.includes("공모전") ||
-		event.title.includes("인턴십") ||
-		event.title.includes("학생기자딘")
-	) {
-		// 인턴십, 공모전 : 신청형 기간제 행사임에도 eventStart, eventEnd 데이터가 들어있는 경우 있음
-		// -> 일괄적으로 기간제 행사 처리
-		isPeriodEvent = true;
-	} else if (isLongerThan(event.eventStart, event.eventEnd, 7)) {
-		// eventEnd-eventStart > 일주일 에 해당하는 긴 행사들의 경우, 차라리 기간제 행사처럼 처리
-		isPeriodEvent = true;
-	} else {
-		// 이외 : eventStart & eventEnd가 있음
-		isPeriodEvent = false;
-	}
+	const isPeriodEvent = event.isPeriodEvent;
+	// if (!event.eventStart || !event.eventEnd) {
+	// 	// 기본 : eventStart 혹은 eventEnd가 없으면 기간제 행사 처리
+	// 	isPeriodEvent = true;
+	// } else if (
+	// 	event.title.includes("공모전") ||
+	// 	event.title.includes("인턴십") ||
+	// 	event.title.includes("학생기자딘")
+	// ) {
+	// 	// 인턴십, 공모전 : 신청형 기간제 행사임에도 eventStart, eventEnd 데이터가 들어있는 경우 있음
+	// 	// -> 일괄적으로 기간제 행사 처리
+	// 	isPeriodEvent = true;
+	// } else if (isLongerThan(event.eventStart, event.eventEnd, 7)) {
+	// 	// eventEnd-eventStart > 일주일 에 해당하는 긴 행사들의 경우, 차라리 기간제 행사처럼 처리
+	// 	isPeriodEvent = true;
+	// } else {
+	// 	// 이외 : eventStart & eventEnd가 있음
+	// 	isPeriodEvent = false;
+	// }
 
 	const startDate =
 		(isPeriodEvent ? event.applyStart : event.eventStart) ||

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -27,6 +27,7 @@ interface EventBase {
 
 	applyLink: string; // 지원 url
 	tags?: string;
+	isPeriodEvent: boolean;
 
 	// following properties are only on BlockEvents
 	capacity: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -20,8 +20,8 @@ interface EventBase {
 
 	operationMode: string; // 온라인 오프라인 온오프라인 병행
 
-	statusId: number; // 1 : 모집중, 2 : 마감
-	eventTypeId: number; // 1: 교육(특강/세미나) 2:공모전/경진대회 3:현장학습/인턴 4:사회공헌/봉사 5:학습/진로상담 6:레크리에이션 6:기타
+	statusId: number; // 1 : 모집 대기, 2 : 모집 중, 3: 모집 마감
+	eventTypeId: number; // 1: 교육(특강/세미나) 2:공모전/경진대회 3:현장학습/인턴 4:사회공헌/봉사 5:학습/진로상담 6:OpenLnL 7:기타
 	orgId: number; // 주체기관 id - FE에서는 사용 X
 	organization: string; // 주체기관 id
 

--- a/src/widgets/DetailView/index.tsx
+++ b/src/widgets/DetailView/index.tsx
@@ -111,8 +111,8 @@ const DetailView = ({ eventId }: { eventId: number }) => {
 			)}
 			<button type="button" className={styles.foldBtn}>
 				<FaAnglesRight
-					width={18}
-					height={18}
+					width={25}
+					height={25}
 					color="rgba(171, 171, 171, 1)"
 					onClick={() => setShowDetail(false)}
 				/>

--- a/src/widgets/DetailView/index.tsx
+++ b/src/widgets/DetailView/index.tsx
@@ -109,12 +109,11 @@ const DetailView = ({ eventId }: { eventId: number }) => {
 				/* Loading spinner */
 				<Loading />
 			)}
-			<button type="button" className={styles.foldBtn}>
+			<button type="button" className={styles.foldBtn} onClick={() => setShowDetail(false)}>
 				<FaAnglesRight
-					width={25}
-					height={25}
+					width={28}
+					height={28}
 					color="rgba(171, 171, 171, 1)"
-					onClick={() => setShowDetail(false)}
 				/>
 			</button>
 

--- a/src/widgets/Month/MonthEvent.tsx
+++ b/src/widgets/Month/MonthEvent.tsx
@@ -1,19 +1,121 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CATEGORY_COLORS, CATEGORY_TEXT_COLORS } from "@constants";
 import type { CalendarEvent } from "@types";
 import styles from "@styles/MonthEvent.module.css";
 import { CATEGORY_OTHER_INDEX } from "@constants";
+import { useMonthEventPreview } from "./MonthEventPreviewContext";
+
+const LONG_PRESS_DURATION = 250;
+const TOUCH_MOVE_THRESHOLD = 10;
 
 const MonthEvent = ({ event: calendarEvent }: { event: CalendarEvent }) => {
 	const { isPeriodEvent, event } = calendarEvent.resource;
-	const backgroundColor = CATEGORY_COLORS[event.eventTypeId] || CATEGORY_COLORS[CATEGORY_OTHER_INDEX];
-	const color = CATEGORY_TEXT_COLORS[event.eventTypeId] || CATEGORY_TEXT_COLORS[CATEGORY_OTHER_INDEX];
-	
+	const backgroundColor =
+		CATEGORY_COLORS[event.eventTypeId] || CATEGORY_COLORS[CATEGORY_OTHER_INDEX];
+	const color =
+		CATEGORY_TEXT_COLORS[event.eventTypeId] ||
+		CATEGORY_TEXT_COLORS[CATEGORY_OTHER_INDEX];
+
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const timerRef = useRef<number | null>(null);
+	const longPressedRef = useRef(false);
+	const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+	const [isTouchDevice, setIsTouchDevice] = useState(false);
+	const { openPreview } = useMonthEventPreview();
+
+	useEffect(() => {
+		const mq = window.matchMedia("(hover: none) and (pointer: coarse)");
+		const update = () => setIsTouchDevice(mq.matches);
+		update();
+		mq.addEventListener("change", update);
+		return () => mq.removeEventListener("change", update);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+		};
+	}, []);
+
+	const clearTimer = useCallback(() => {
+		if (timerRef.current !== null) {
+			window.clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	const handleTouchStart = useCallback(
+		(e: React.TouchEvent<HTMLDivElement>) => {
+			if (!isTouchDevice) return;
+			longPressedRef.current = false;
+			clearTimer();
+			const touch = e.touches[0];
+			touchStartPos.current = { x: touch.clientX, y: touch.clientY };
+			timerRef.current = window.setTimeout(() => {
+				const el = containerRef.current;
+				if (!el) return;
+				const rect = el.getBoundingClientRect();
+				const placement = rect.top < window.innerHeight / 2 ? "below" : "above";
+				const top = placement === "below" ? rect.bottom + 8 : rect.top - 8;
+				const left = rect.left + rect.width / 2;
+				longPressedRef.current = true;
+				openPreview({
+					id: event.id,
+					title: event.title,
+					top,
+					left,
+					placement,
+					backgroundColor,
+				});
+			}, LONG_PRESS_DURATION);
+		},
+		[
+			isTouchDevice,
+			clearTimer,
+			event.id,
+			event.title,
+			backgroundColor,
+			openPreview,
+		],
+	);
+
+	const handleTouchMove = useCallback(
+		(e: React.TouchEvent<HTMLDivElement>) => {
+			if (!touchStartPos.current) return;
+			const touch = e.touches[0];
+			const dx = touch.clientX - touchStartPos.current.x;
+			const dy = touch.clientY - touchStartPos.current.y;
+			if (Math.hypot(dx, dy) > TOUCH_MOVE_THRESHOLD) {
+				clearTimer();
+			}
+		},
+		[clearTimer],
+	);
+
+	const handleTouchEnd = useCallback(() => {
+		clearTimer();
+		touchStartPos.current = null;
+	}, [clearTimer]);
+
+	const handleClick = useCallback((e: React.MouseEvent) => {
+		if (longPressedRef.current) {
+			e.stopPropagation();
+			e.preventDefault();
+			longPressedRef.current = false;
+		}
+	}, []);
+
 	// 기간제 행사 : 화살표
 	if (isPeriodEvent) {
 		return (
 			<div className={styles.arrowEventContainer} style={{ color: color }}>
 				<span className={styles.arrowText}>{event.title}</span>
-				<div className={styles.arrowLine} style={{ backgroundColor: backgroundColor }}>
+				<div
+					className={styles.arrowLine}
+					style={{ backgroundColor: backgroundColor }}
+				>
 					<div
 						className={`${styles.arrowHead} ${styles.left}`}
 						style={{ borderRightColor: backgroundColor }}
@@ -26,13 +128,25 @@ const MonthEvent = ({ event: calendarEvent }: { event: CalendarEvent }) => {
 			</div>
 		);
 	}
+
 	// 단발성 행사 : 블록
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: onClick suppresses synthesized click after long-press; click handling for the event itself stays on react-big-calendar's wrapper
+		// biome-ignore lint/a11y/useKeyWithClickEvents: keyboard activation is handled by the parent calendar wrapper
 		<div
+			ref={containerRef}
 			className={styles.blockEventContainer}
 			style={{
 				backgroundColor: backgroundColor,
 			}}
+			data-month-event-id={event.id}
+			data-event-title={event.title}
+			data-event-bg={backgroundColor}
+			onTouchStart={handleTouchStart}
+			onTouchMove={handleTouchMove}
+			onTouchEnd={handleTouchEnd}
+			onTouchCancel={handleTouchEnd}
+			onClick={handleClick}
 		>
 			{event.title}
 		</div>

--- a/src/widgets/Month/MonthEventPreviewContext.tsx
+++ b/src/widgets/Month/MonthEventPreviewContext.tsx
@@ -1,0 +1,152 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import styles from "@styles/MonthEvent.module.css";
+
+export type MonthEventPreviewState = {
+	id: number;
+	title: string;
+	top: number;
+	left: number;
+	placement: "above" | "below";
+	backgroundColor: string;
+};
+
+type ContextValue = {
+	openPreview: (state: MonthEventPreviewState) => void;
+	closePreview: () => void;
+};
+
+const MonthEventPreviewContext = createContext<ContextValue | null>(null);
+
+export const useMonthEventPreview = () => {
+	const ctx = useContext(MonthEventPreviewContext);
+	if (!ctx)
+		throw new Error(
+			"useMonthEventPreview must be used inside MonthEventPreviewProvider",
+		);
+	return ctx;
+};
+
+const VIEWPORT_MARGIN = 8;
+
+const computePosition = (rect: DOMRect) => {
+	const placement: "above" | "below" =
+		rect.top < window.innerHeight / 2 ? "below" : "above";
+	const top = placement === "below" ? rect.bottom + 8 : rect.top - 8;
+	const left = rect.left + rect.width / 2;
+	return { top, left, placement };
+};
+
+export const MonthEventPreviewProvider = ({
+	children,
+}: {
+	children: ReactNode;
+}) => {
+	const [preview, setPreview] = useState<MonthEventPreviewState | null>(null);
+	const previewRef = useRef<MonthEventPreviewState | null>(null);
+	const previewElRef = useRef<HTMLDivElement | null>(null);
+	const isOpen = preview !== null;
+
+	const closePreview = useCallback(() => {
+		previewRef.current = null;
+		setPreview(null);
+	}, []);
+
+	const openPreview = useCallback((state: MonthEventPreviewState) => {
+		previewRef.current = state;
+		setPreview(state);
+	}, []);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const handleTouchMove = (e: TouchEvent) => {
+			e.preventDefault();
+			const touch = e.touches[0];
+			if (!touch) return;
+			const target = document.elementFromPoint(touch.clientX, touch.clientY);
+			const block = target?.closest<HTMLElement>("[data-month-event-id]");
+			if (!block) return;
+			const id = Number(block.dataset.monthEventId);
+			if (Number.isNaN(id)) return;
+			if (previewRef.current && id === previewRef.current.id) return;
+			const { top, left, placement } = computePosition(
+				block.getBoundingClientRect(),
+			);
+			const next: MonthEventPreviewState = {
+				id,
+				title: block.dataset.eventTitle ?? "",
+				top,
+				left,
+				placement,
+				backgroundColor: block.dataset.eventBg ?? "",
+			};
+			previewRef.current = next;
+			setPreview(next);
+		};
+
+		const handleEnd = () => {
+			closePreview();
+		};
+
+		window.addEventListener("touchmove", handleTouchMove, { passive: false });
+		window.addEventListener("touchend", handleEnd);
+		window.addEventListener("touchcancel", handleEnd);
+
+		return () => {
+			window.removeEventListener("touchmove", handleTouchMove);
+			window.removeEventListener("touchend", handleEnd);
+			window.removeEventListener("touchcancel", handleEnd);
+		};
+	}, [isOpen, closePreview]);
+
+	// 가로 클램프: preview의 실제 너비를 측정해 viewport 밖으로 나가지 않도록 left 보정
+	useLayoutEffect(() => {
+		if (!preview || !previewElRef.current) return;
+		const width = previewElRef.current.offsetWidth;
+		const halfW = width / 2;
+		const minLeft = VIEWPORT_MARGIN + halfW;
+		const maxLeft = window.innerWidth - VIEWPORT_MARGIN - halfW;
+		if (minLeft > maxLeft) return; // preview가 viewport보다 넓으면 보정 불가
+		const clamped = Math.max(minLeft, Math.min(maxLeft, preview.left));
+		if (Math.abs(clamped - preview.left) > 0.5) {
+			const next = { ...preview, left: clamped };
+			previewRef.current = next;
+			setPreview(next);
+		}
+	}, [preview]);
+
+	return (
+		<MonthEventPreviewContext.Provider value={{ openPreview, closePreview }}>
+			{children}
+			{preview &&
+				createPortal(
+					<div
+						ref={previewElRef}
+						className={styles.preview}
+						style={{
+							top: preview.top,
+							left: preview.left,
+							transform:
+								preview.placement === "below"
+									? "translateX(-50%)"
+									: "translate(-50%, -100%)",
+							backgroundColor: preview.backgroundColor,
+						}}
+					>
+						{preview.title}
+					</div>,
+					document.body,
+				)}
+		</MonthEventPreviewContext.Provider>
+	);
+};

--- a/src/widgets/Month/MonthSideView/MonthSideView.tsx
+++ b/src/widgets/Month/MonthSideView/MonthSideView.tsx
@@ -8,6 +8,7 @@ import calendarEventMapper from "@/util/Calendar/calendarEventMapper";
 import { Views } from "react-big-calendar";
 import type { CalendarEvent, Event } from "@/util/types";
 import { startOfDay, isWithinInterval } from 'date-fns';
+import { IoClose } from "react-icons/io5";
 
 const MonthSideView = ({
 	day,
@@ -67,22 +68,29 @@ const MonthSideView = ({
 
 	return (
 		<div className={styles.mainWrapper}>
-			<FaAnglesRight
-				width={24}
-				color="rgba(171, 171, 171, 1)"
-				onClick={onClose}
-			/>
-			<div className={styles.dateRow}>
+			<button type="button" className={styles.foldBtn} onClick={onClose}>
+				<FaAnglesRight
+					width={24}
+					color="rgba(171, 171, 171, 1)"
+				/>
+			</button>
+			<div className={styles.dateRow}>			
 				<h1>{`${date.getMonth() + 1}월 ${date.getDate()}일`}</h1>
-				<button type="button" onClick={handleClickToday}>
+				<button type="button" className={styles.todayBtn} onClick={handleClickToday}>
 					오늘
 				</button>
-				<button type="button" onClick={handleClickPrevday}>
-					<FaAngleLeft width={18} color="rgba(171, 171, 171, 1)" />
+				<button type="button" className={styles.dateChangeBtn} onClick={handleClickPrevday}>
+					<FaAngleLeft size={24} color="rgba(171, 171, 171, 1)" />
 				</button>
-				<button type="button" onClick={handleClickNextday}>
-					<FaAngleRight width={18} color="rgba(171, 171, 171, 1)" />
+				<button type="button" className={styles.dateChangeBtn} onClick={handleClickNextday}>
+					<FaAngleRight size={24} color="rgba(171, 171, 171, 1)" />
 				</button>
+				<button type="button" className={`${styles.mobileCloseBtn}`} onClick={onClose}>
+					<IoClose
+						size={24}
+						color="rgba(171, 171, 171, 1)"
+					/>
+				</button>	
 			</div>
 			<div className={styles.cardWrapper}>
 				{events.map((event) => (

--- a/src/widgets/Month/MonthSideView/MonthSideView.tsx
+++ b/src/widgets/Month/MonthSideView/MonthSideView.tsx
@@ -1,4 +1,3 @@
-// 필요 : get events by day (get all)
 import { useEffect, useState } from "react";
 import { FaAngleLeft, FaAngleRight, FaAnglesRight } from "react-icons/fa6";
 import { useEvents } from "@contexts/EventContext";
@@ -69,7 +68,7 @@ const MonthSideView = ({
 	return (
 		<div className={styles.mainWrapper}>
 			<FaAnglesRight
-				width={18}
+				width={24}
 				color="rgba(171, 171, 171, 1)"
 				onClick={onClose}
 			/>

--- a/src/widgets/MyCalendar.tsx
+++ b/src/widgets/MyCalendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Calendar, type View, Views } from "react-big-calendar";
 import styles from "@styles/Calendar.module.css";
 import { localizer } from "@calendarUtil/calendarLocalizer";
@@ -34,6 +34,7 @@ export const MyCalendar = ({
 }: MyCalendarProps) => {
 	const { dayDate, setDayDate } = useEvents();
 	const [currentView, setCurrentView] = useState<View>(Views.MONTH);
+	const [isMobile, setIsMobile] = useState(false);
 
 	const onNavigate = useCallback(
 		(newDate: Date) => {
@@ -42,6 +43,7 @@ export const MyCalendar = ({
 		[setDayDate],
 	);
 
+	/** Event Mapping */
 	const currentEvents = useMemo(() => {
 		switch (currentView) {
 			case Views.MONTH:
@@ -59,6 +61,7 @@ export const MyCalendar = ({
 		return currentEvents.map((e: Event) => calendarEventMapper(e, currentView));
 	}, [currentEvents, currentView]);
 
+	/** Calendar format */
 	const formats = useMemo(
 		() => ({
 			monthHeaderFormat: "yyyy년 M월",
@@ -92,6 +95,7 @@ export const MyCalendar = ({
 		[],
 	);
 
+	/** '더 보기' 문구에 표시되지 않은 행사 수를 어떻게 표시할지 포맷 */
 	const messages = useMemo(
 		() => ({
 			showMore: (total: number) => `+${total}`,
@@ -99,6 +103,38 @@ export const MyCalendar = ({
 		[],
 	);
 
+	/** 모바일 환경인지 검증
+	 * -> 모바일이면 개별 행사 선택 불가 : onSelectEvent prop에 onDrillDown과 같은 동작 하도록 전달
+	 * (개별 행사 선택 = 날짜 선택 = 해당 날짜 행사 목록 보여주는 MonthSideview 렌더링)
+	 */
+	useEffect(() => {
+		const checkIsMobile = () => {
+			setIsMobile(window.innerWidth <= 576);
+		};
+		
+		checkIsMobile();
+		window.addEventListener("resize", checkIsMobile);
+
+		return () => {
+			window.removeEventListener("resize", checkIsMobile);
+		}
+	}, []);
+
+	/** 날짜 클릭 핸들러 함수 - onDrillDown */
+	const handleDrillDown = useCallback(
+		(date: Date) => {
+			onShowMoreClick(date, Views.MONTH);
+		},[onShowMoreClick],);
+
+	const handleSelectEvent = useCallback(
+		(event: CalendarEvent) => {
+			if (isMobile) {
+				handleDrillDown(event.start);
+				return;
+			}
+			onSelectEvent(event);
+		}, [isMobile, handleDrillDown, onSelectEvent]);
+		
 	return (
 		<div className={styles.main}>
 			<Calendar
@@ -135,13 +171,11 @@ export const MyCalendar = ({
 				formats={formats}
 				// 더보기 눌렀을 때 popup 나타나기 X, 사이드뷰 나타남
 				popup={false}
-				onDrillDown={(date: Date) => {
-					onShowMoreClick(date, Views.MONTH);
-				}}
+				onDrillDown={handleDrillDown}
 				// 더보기 미리보기
 				messages={messages}
 				// 행사 눌렀을 때 상세 뷰 나타나게 하기 :
-				onSelectEvent={onSelectEvent}
+				onSelectEvent={handleSelectEvent}
 			/>
 		</div>
 	);

--- a/src/widgets/MyCalendar.tsx
+++ b/src/widgets/MyCalendar.tsx
@@ -5,6 +5,7 @@ import { localizer } from "@calendarUtil/calendarLocalizer";
 import type { CalendarEvent, Event } from "@types";
 import Toolbar from "./Toolbar";
 import MonthEvent from "./Month/MonthEvent";
+import { MonthEventPreviewProvider } from "./Month/MonthEventPreviewContext";
 import DayEvent from "./Day/DayEvent";
 import CustomDayView from "./Day/CustomDayView";
 import CustomWeekView from "./Week/CustomWeekView";
@@ -111,20 +112,22 @@ export const MyCalendar = ({
 		const checkIsMobile = () => {
 			setIsMobile(window.innerWidth <= 576);
 		};
-		
+
 		checkIsMobile();
 		window.addEventListener("resize", checkIsMobile);
 
 		return () => {
 			window.removeEventListener("resize", checkIsMobile);
-		}
+		};
 	}, []);
 
 	/** 날짜 클릭 핸들러 함수 - onDrillDown */
 	const handleDrillDown = useCallback(
 		(date: Date) => {
 			onShowMoreClick(date, Views.MONTH);
-		},[onShowMoreClick],);
+		},
+		[onShowMoreClick],
+	);
 
 	const handleSelectEvent = useCallback(
 		(event: CalendarEvent) => {
@@ -133,50 +136,54 @@ export const MyCalendar = ({
 				return;
 			}
 			onSelectEvent(event);
-		}, [isMobile, handleDrillDown, onSelectEvent]);
-		
+		},
+		[isMobile, handleDrillDown, onSelectEvent],
+	);
+
 	return (
-		<div className={styles.main}>
-			<Calendar
-				localizer={localizer}
-				events={CALENDER_EVENTS}
-				startAccessor="start"
-				endAccessor="end"
-				style={{ height: "100%" }}
-				// custom toolbar
-				components={{
-					toolbar: Toolbar,
-					// event: MonthEvent,
-					month: {
-						event: MonthEvent,
-					},
-					day: {
-						event: DayEvent,
-					},
-				}}
-				// style function
-				eventPropGetter={eventPropGetter}
-				date={dayDate}
-				// view setup
-				view={currentView}
-				onView={(view) => setCurrentView(view)}
-				views={{
-					month: true,
-					week: CustomWeekView,
-					day: CustomDayView,
-				}}
-				onNavigate={onNavigate}
-				defaultView={Views.MONTH}
-				// 한국어 형식
-				formats={formats}
-				// 더보기 눌렀을 때 popup 나타나기 X, 사이드뷰 나타남
-				popup={false}
-				onDrillDown={handleDrillDown}
-				// 더보기 미리보기
-				messages={messages}
-				// 행사 눌렀을 때 상세 뷰 나타나게 하기 :
-				onSelectEvent={handleSelectEvent}
-			/>
-		</div>
+		<MonthEventPreviewProvider>
+			<div className={styles.main}>
+				<Calendar
+					localizer={localizer}
+					events={CALENDER_EVENTS}
+					startAccessor="start"
+					endAccessor="end"
+					style={{ height: "100%" }}
+					// custom toolbar
+					components={{
+						toolbar: Toolbar,
+						// event: MonthEvent,
+						month: {
+							event: MonthEvent,
+						},
+						day: {
+							event: DayEvent,
+						},
+					}}
+					// style function
+					eventPropGetter={eventPropGetter}
+					date={dayDate}
+					// view setup
+					view={currentView}
+					onView={(view) => setCurrentView(view)}
+					views={{
+						month: true,
+						week: CustomWeekView,
+						day: CustomDayView,
+					}}
+					onNavigate={onNavigate}
+					defaultView={Views.MONTH}
+					// 한국어 형식
+					formats={formats}
+					// 더보기 눌렀을 때 popup 나타나기 X, 사이드뷰 나타남
+					popup={false}
+					onDrillDown={handleDrillDown}
+					// 더보기 미리보기
+					messages={messages}
+					// 행사 눌렀을 때 상세 뷰 나타나게 하기 :
+					onSelectEvent={handleSelectEvent}
+				/>
+			</div>
+		</MonthEventPreviewProvider>
 	);
 };

--- a/src/widgets/Sidebar.tsx
+++ b/src/widgets/Sidebar.tsx
@@ -141,7 +141,7 @@ export const Sidebar = () => {
 			navigate("/main");
 		} else {
 			// else : go to login page
-			navigate("/auth/login");
+			navigate("/");
 		}
 	};
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

모바일 환경에서 캘린더 이벤트를 더 자연스럽게 확인하고 조작할 수 있도록 UI/UX를 개선했습니다.

* **스크린샷**
<img  height="600" alt="IMG_9393" src="https://github.com/user-attachments/assets/749ad5da-78b1-4764-93d9-65102da517a1" />


* **동작 영상**
https://github.com/user-attachments/assets/0cfa4e79-b9de-47fb-9c61-1d0c5c75b1df


**주요 변경 사항**
- 모바일 뷰에서 이벤트 클릭 동작을 구현했습니다.
- calendarEventMapper에서 서버 스키마의 isPeriodEvent 값을 사용하도록 수정했습니다.
- 모바일 툴바의 padding-top을 조정했습니다.
- 모바일 화면에서 CalendarView 페이지의 padding을 최적화했습니다.
- 버튼 스타일을 정리하고 모바일 UI에 맞게 조정했습니다.
- 모바일 뷰에서 BlockEvent 미리보기를 추가했습니다.
- 드래그 중 미리보기 위치가 함께 이동하도록 개선했습니다.
- DetailView 내부 HTML 이미지가 컨테이너 안에 맞게 표시되도록 수정했습니다.

## ✅ 체크리스트
- [X] 로컬에서 정상 동작 확인
- [X] 기존 기능에 영향 없음
- [X] 테스트 통과 (또는 테스트 없음)
- [X] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
