### PR TITLE
시간표 토글 버튼 라벨 추가, 레이아웃 수정, 로딩 화면 개선

### DIFF
--- a/src/pages/timetable/TimeTableToolbar.tsx
+++ b/src/pages/timetable/TimeTableToolbar.tsx
@@ -36,47 +36,52 @@ const TimeTableToolbar = ({
 		<div className={styles.timetableToolbarContainer}>
 			<div className={styles.headerRow}>
 				<div className={styles.selectGroup}>
-					<span className={styles.selectWrap}>
-						<select
-							className={styles.select}
-							value={year}
-							onChange={(e) => onYearChange(Number(e.target.value))}
-							aria-label="년도 선택"
-						>
-							{yearOptions.map((y) => (
-								<option key={y} value={y}>
-									{y}학년도
-								</option>
-							))}
-						</select>
-					</span>
+					<div className={styles.semesterSelectGroup}>
+						<span className={styles.selectWrap}>
+							<select
+								className={styles.select}
+								value={year}
+								onChange={(e) => onYearChange(Number(e.target.value))}
+								aria-label="년도 선택"
+							>
+								{yearOptions.map((y) => (
+									<option key={y} value={y}>
+										{y}학년도
+									</option>
+								))}
+							</select>
+						</span>
 
-					<span className={styles.selectWrap}>
-						<select
-							className={styles.select}
-							value={semester}
-							onChange={(e) => onSemesterChange(e.target.value as Semester)}
-							aria-label="학기 선택"
-						>
-							{SEMESTER_LABEL.map((s) => (
-								<option key={s.id} value={s.id}>
-									{s.label}
-								</option>
-							))}
-						</select>
-					</span>
+						<span className={styles.selectWrap}>
+							<select
+								className={styles.select}
+								value={semester}
+								onChange={(e) => onSemesterChange(e.target.value as Semester)}
+								aria-label="학기 선택"
+							>
+								{SEMESTER_LABEL.map((s) => (
+									<option key={s.id} value={s.id}>
+										{s.label}
+									</option>
+								))}
+							</select>
+						</span>
+					</div>
 					<p className={styles.dateTitle}>{timetableName}</p>
-					<button
-						type="button"
-						className={`${styles.timetableToggle} ${
-							isToggleOn ? styles.timetableToggleOn : ""
-						}`}
-						aria-label="시간표 토글"
-						aria-pressed={isToggleOn}
-						onClick={() => onToggleChange(!isToggleOn)}
-					>
-						<span className={styles.timetableToggleThumb} />
-					</button>
+					<div className={styles.timetableToggleGroup}>
+						<span className={styles.timetableToggleLabel}>행사 함께 보기</span>
+						<button
+							type="button"
+							className={`${styles.timetableToggle} ${
+								isToggleOn ? styles.timetableToggleOn : ""
+							}`}
+							aria-label="행사 함께 보기"
+							aria-pressed={isToggleOn}
+							onClick={() => onToggleChange(!isToggleOn)}
+						>
+							<span className={styles.timetableToggleThumb} />
+						</button>
+					</div>
 				</div>
 
 				<div className={styles.profileRow}>

--- a/src/pages/timetable/TimeTableToolbar.tsx
+++ b/src/pages/timetable/TimeTableToolbar.tsx
@@ -13,6 +13,7 @@ interface TimeTableToolbarProps {
 	onSemesterChange: (semester: Semester) => void;
 	isToggleOn: boolean;
 	onToggleChange: (isToggleOn: boolean) => void;
+	isLoading?: boolean;
 	years?: number[];
 }
 
@@ -25,6 +26,7 @@ const TimeTableToolbar = ({
 	onSemesterChange,
 	isToggleOn,
 	onToggleChange,
+	isLoading = false,
 	years,
 }: TimeTableToolbarProps) => {
 	const { user } = useAuth();
@@ -41,6 +43,7 @@ const TimeTableToolbar = ({
 							<select
 								className={styles.select}
 								value={year}
+								disabled={isLoading}
 								onChange={(e) => {
 									onYearChange(Number(e.target.value));
 									e.currentTarget.blur();
@@ -59,6 +62,7 @@ const TimeTableToolbar = ({
 							<select
 								className={styles.select}
 								value={semester}
+								disabled={isLoading}
 								onChange={(e) => {
 									onSemesterChange(e.target.value as Semester);
 									e.currentTarget.blur();

--- a/src/pages/timetable/TimeTableToolbar.tsx
+++ b/src/pages/timetable/TimeTableToolbar.tsx
@@ -41,7 +41,10 @@ const TimeTableToolbar = ({
 							<select
 								className={styles.select}
 								value={year}
-								onChange={(e) => onYearChange(Number(e.target.value))}
+								onChange={(e) => {
+									onYearChange(Number(e.target.value));
+									e.currentTarget.blur();
+								}}
 								aria-label="년도 선택"
 							>
 								{yearOptions.map((y) => (
@@ -56,7 +59,10 @@ const TimeTableToolbar = ({
 							<select
 								className={styles.select}
 								value={semester}
-								onChange={(e) => onSemesterChange(e.target.value as Semester)}
+								onChange={(e) => {
+									onSemesterChange(e.target.value as Semester);
+									e.currentTarget.blur();
+								}}
 								aria-label="학기 선택"
 							>
 								{SEMESTER_LABEL.map((s) => (

--- a/src/pages/timetable/TimetableGrid.tsx
+++ b/src/pages/timetable/TimetableGrid.tsx
@@ -33,6 +33,7 @@ export type TimetableProps = {
 	onAddBlock?: (id: number, item: Course) => void;
 	onRemoveBlock?: (timetableId: number, enrollId: number) => Promise<void>;
 	isSimplified?: boolean;
+	isLoading?: boolean;
 	weekEvents?: CalendarEvent[];
 	onSelectEvent?: (event: Event) => void;
 	dayLabels?: Record<Day, string>;
@@ -47,6 +48,7 @@ export function TimetableGrid({
 	toBlocks,
 	onRemoveBlock,
 	isSimplified = false,
+	isLoading = false,
 	weekEvents = [],
 	onSelectEvent,
 	dayLabels = DAY_LABELS_KO,
@@ -118,7 +120,9 @@ export function TimetableGrid({
 	}, [weekEvents, config]);
 
 	return (
-		<div className={styles.gridWrap}>
+		<div
+			className={`${styles.gridWrap} ${isLoading ? styles.gridWrapLoading : ""}`}
+		>
 			<div className={styles.headerRow}>
 				<div className={styles.timeGutterHeader} />
 				{Days.map((d) => (

--- a/src/pages/timetable/TimetablePage.tsx
+++ b/src/pages/timetable/TimetablePage.tsx
@@ -38,7 +38,6 @@ export default function TimetablePage() {
 		courses,
 		currentTimetable,
 		createTimetable,
-		isLoading,
 		loadTimetable,
 		selectTimetable,
 		updateTimetableName,
@@ -157,8 +156,6 @@ export default function TimetablePage() {
 					calendarEvent.allDay === false,
 			);
 	}, [weekViewData]);
-
-	if (isLoading) return <div>로딩 중...</div>;
 
 	return (
 		<div

--- a/src/pages/timetable/TimetablePage.tsx
+++ b/src/pages/timetable/TimetablePage.tsx
@@ -38,6 +38,7 @@ export default function TimetablePage() {
 		courses,
 		currentTimetable,
 		createTimetable,
+		isLoading,
 		loadTimetable,
 		selectTimetable,
 		updateTimetableName,
@@ -191,6 +192,7 @@ export default function TimetablePage() {
 					onYearChange={setYear}
 					isToggleOn={isTimetableSimplified}
 					onToggleChange={setIsTimetableSimplified}
+					isLoading={isLoading}
 					years={years}
 				/>
 
@@ -211,6 +213,7 @@ export default function TimetablePage() {
 						toBlocks={flattenCoursesToBlocks}
 						onRemoveBlock={deleteCourse}
 						isSimplified={isTimetableSimplified}
+						isLoading={isLoading}
 						weekEvents={isTimetableSimplified ? weekCalendarEvents : []}
 					/>
 				)}

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -232,6 +232,12 @@
 
 .gridWrap {
 	min-width: 860px;
+	transition: opacity 0.18s ease;
+}
+
+.gridWrapLoading {
+	opacity: 0.48;
+	pointer-events: none;
 }
 
 .headerRow {

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -224,8 +224,31 @@
 .selectGroup {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 25px;
   min-width: 0;
+}
+
+.semesterSelectGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.timetableToggleGroup {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.timetableToggleLabel {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  color: #6b7280;
+  white-space: nowrap;
 }
 
 .timetableToggle {
@@ -322,6 +345,9 @@
     flex: 1;
     gap: 8px;
   }
+  .timetableToolbarContainer .semesterSelectGroup {
+    display: none;
+  }
   .timetableToolbarContainer .selectWrap {
     display: none;
   }
@@ -334,6 +360,12 @@
     line-height: 1.25;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .timetableToolbarContainer .timetableToggleGroup {
+    align-items: flex-start;
+  }
+  .timetableToolbarContainer .timetableToggleLabel {
+    display: none;
   }
   .timetableToolbarContainer .timetableToggle {
     width: 38px;

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -311,6 +311,12 @@
   background: #fafafa;
 }
 
+.select:disabled {
+  color: #8a8a8a;
+  cursor: wait;
+  background: #f7f7f7;
+}
+
 .select:focus {
   border-color: #d0d0d0;
   box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 시간표 토글 버튼 라벨 추가 및 레이아웃 수정
<img width="387" height="98" alt="image" src="https://github.com/user-attachments/assets/1b3967d6-ca06-4130-b67c-48bdf4239ed6" />
2. 로딩화면 개선
- 년도, 학기 선택 시 로딩 화면 개선
- 기존의 "로딩 중" 표시 대신 선택 버튼 비활성화 & 그리드 색상 변경

https://github.com/user-attachments/assets/210d402e-e111-4091-9137-516aa686e52d

## ✅ 체크리스트
- [✅] 로컬에서 정상 동작 확인
- [✅] 기존 기능에 영향 없음
- [✅] 테스트 통과 (또는 테스트 없음)
- [✅] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
