### PR TITLE
feat: add create / overridenfields lock&unlock to admin page

### DIFF
--- a/src/api/adminEvent.ts
+++ b/src/api/adminEvent.ts
@@ -32,35 +32,55 @@ export interface AdminEventDetailResponse {
 	detail?: string | null;
 }
 
-export interface AdminEventPatchRequest {
+export interface AdminEventRequest {
 	title?: string | null;
 	imageUrl?: string | null;
 	operationMode?: string | null;
-
-	tags?: string[] | null;
-	mainContentHtml?: string | null;
-
 	statusId?: number | null;
 	eventTypeId?: number | null;
 	orgId?: number | null;
-
 	applyStart?: string | null;
 	applyEnd?: string | null;
 	eventStart?: string | null;
 	eventEnd?: string | null;
-
 	capacity?: number | null;
 	applyCount?: number | null;
-
+	applyLink?: string | null;
 	organization?: string | null;
 	location?: string | null;
-	applyLink?: string | null;
+	tags?: string[];
+	mainContentHtml?: string | null;
 }
 
 export const getAdminEvent = async (
 	eventId: number,
 ): Promise<AdminEventDetailResponse> => {
 	const res = await api.get<AdminEventDetailResponse>(`/events/${eventId}`);
+	return res.data;
+};
+
+export interface AdminEventCreateRequest extends AdminEventRequest {
+	title: string;
+}
+
+export type AdminEventPatchRequest = AdminEventRequest;
+
+export interface AdminEventOverrideUpdateRequest {
+	lockFields?: string[];
+	unlockFields?: string[];
+}
+
+export interface AdminEventOverrideUpdateResponse extends AdminActionResponse {
+	eventId: number;
+	adminOverriddenFields: string[];
+}
+
+export const createAdminEvent = async (
+	body: AdminEventCreateRequest,
+): Promise<AdminActionResponse> => {
+	const res = await api.post<AdminActionResponse>("/admin/events", body, {
+		baseURL: "",
+	});
 	return res.data;
 };
 
@@ -104,5 +124,17 @@ export const syncAdminEventsFile = async (
 		{ baseURL: "" },
 	);
 
+	return res.data;
+};
+
+export const updateAdminEventOverrides = async (
+	eventId: number,
+	body: AdminEventOverrideUpdateRequest,
+): Promise<AdminEventOverrideUpdateResponse> => {
+	const res = await api.patch<AdminEventOverrideUpdateResponse>(
+		`/admin/events/${eventId}/overrides`,
+		body,
+		{ baseURL: "" },
+	);
 	return res.data;
 };

--- a/src/pages/AdminEvents.tsx
+++ b/src/pages/AdminEvents.tsx
@@ -1,9 +1,12 @@
 import {
+	createAdminEvent,
 	deleteAdminEvent,
 	deleteAllAdminEvents,
 	getAdminEvent,
 	patchAdminEvent,
 	syncAdminEventsFile,
+	updateAdminEventOverrides,
+	type AdminEventCreateRequest,
 	type AdminEventPatchRequest,
 } from "@/api/adminEvent";
 import { useState } from "react";
@@ -32,6 +35,25 @@ const EMPTY_FORM = {
 	tags: "",
 	mainContentHtml: "",
 };
+
+const OVERRIDABLE_FIELDS: { key: keyof AdminEventForm; label: string }[] = [
+	{ key: "title", label: "제목" },
+	{ key: "imageUrl", label: "이미지 URL" },
+	{ key: "operationMode", label: "운영 방식" },
+	{ key: "statusId", label: "모집 상태 ID" },
+	{ key: "eventTypeId", label: "행사 유형 ID" },
+	{ key: "orgId", label: "기관 ID" },
+	{ key: "applyStart", label: "신청 시작" },
+	{ key: "applyEnd", label: "신청 종료" },
+	{ key: "eventStart", label: "행사 시작" },
+	{ key: "eventEnd", label: "행사 종료" },
+	{ key: "capacity", label: "정원" },
+	{ key: "applyCount", label: "신청자 수" },
+	{ key: "organization", label: "기관명" },
+	{ key: "location", label: "장소" },
+	{ key: "tags", label: "태그" },
+	{ key: "mainContentHtml", label: "상세 HTML" },
+];
 
 type AdminEventForm = typeof EMPTY_FORM;
 
@@ -65,30 +87,36 @@ function toTags(value: string): string[] {
 		.filter((tag) => tag.length > 0);
 }
 
-function buildPatchRequest(form: AdminEventForm): AdminEventPatchRequest {
+function buildEventRequest(form: AdminEventForm): AdminEventPatchRequest {
 	return {
 		title: toNullableString(form.title),
 		imageUrl: toNullableString(form.imageUrl),
 		operationMode: toNullableString(form.operationMode),
-
 		statusId: toNullableNumber(form.statusId),
 		eventTypeId: toNullableNumber(form.eventTypeId),
 		orgId: toNullableNumber(form.orgId),
-
-		applyStart: toDateTime(form.applyStart),
-		applyEnd: toDateTime(form.applyEnd),
-		eventStart: toDateTime(form.eventStart),
-		eventEnd: toDateTime(form.eventEnd),
-
+		applyStart: toNullableString(form.applyStart),
+		applyEnd: toNullableString(form.applyEnd),
+		eventStart: toNullableString(form.eventStart),
+		eventEnd: toNullableString(form.eventEnd),
 		capacity: toNullableNumber(form.capacity),
 		applyCount: toNullableNumber(form.applyCount),
-
+		applyLink: toNullableString(form.applyLink),
 		organization: toNullableString(form.organization),
 		location: toNullableString(form.location),
-		applyLink: toNullableString(form.applyLink),
-
 		tags: toTags(form.tags),
-		mainContentHtml: form.mainContentHtml,
+		mainContentHtml: toNullableString(form.mainContentHtml),
+	};
+}
+
+function buildCreateRequest(form: AdminEventForm): AdminEventCreateRequest | null {
+	const title = form.title.trim();
+
+	if (title.length === 0) return null;
+
+	return {
+		...buildEventRequest(form),
+		title,
 	};
 }
 
@@ -98,9 +126,19 @@ export default function AdminEventsPage() {
 	const [selectedFile, setSelectedFile] = useState<File | null>(null);
 	const [message, setMessage] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
+	const [overrideFields, setOverrideFields] = useState<string[]>([]);
+	const [selectedOverrideFields, setSelectedOverrideFields] = useState<string[]>([]);
 
 	const updateForm = (key: keyof AdminEventForm, value: string) => {
 		setForm((prev) => ({ ...prev, [key]: value }));
+	};
+
+	const toggleOverrideField = (field: string) => {
+		setSelectedOverrideFields((prev) =>
+			prev.includes(field)
+				? prev.filter((item) => item !== field)
+				: [...prev, field],
+		);
 	};
 
 	const getNumericEventId = (): number | null => {
@@ -154,6 +192,32 @@ export default function AdminEventsPage() {
 		}
 	};
 
+	const handleCreate = async () => {
+		const body = buildCreateRequest(form);
+
+		if (body === null) {
+			setMessage("생성할 행사 제목을 입력해주세요.");
+			return;
+		}
+
+		setIsLoading(true);
+
+		try {
+			const result = await createAdminEvent(body);
+			const createdEventId = result.eventId;
+
+			if (typeof createdEventId === "number") {
+				setEventId(String(createdEventId));
+			}
+
+			setMessage(`생성 완료: ${JSON.stringify(result)}`);
+		} catch {
+			setMessage("생성 요청에 실패했습니다.");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
 	const handlePatch = async () => {
 		const id = getNumericEventId();
 
@@ -165,8 +229,9 @@ export default function AdminEventsPage() {
 		setIsLoading(true);
 
 		try {
-			const result = await patchAdminEvent(id, buildPatchRequest(form));
+			const result = await patchAdminEvent(id, buildEventRequest(form));
 			setMessage(`수정 완료: ${JSON.stringify(result)}`);
+			setSelectedOverrideFields([]);
 		} catch {
 			setMessage("수정 요청에 실패했습니다.");
 		} finally {
@@ -219,6 +284,39 @@ export default function AdminEventsPage() {
 		}
 	};
 
+	const handleUpdateOverrides = async (mode: "lock" | "unlock") => {
+		const id = getNumericEventId();
+
+		if (id === null) {
+			setMessage("override를 변경할 행사 ID를 숫자로 입력해주세요.");
+			return;
+		}
+
+		if (selectedOverrideFields.length === 0) {
+			setMessage("lock/unlock할 필드를 선택해주세요.");
+			return;
+		}
+
+		setIsLoading(true);
+
+		try {
+			const result = await updateAdminEventOverrides(id, {
+				lockFields: mode === "lock" ? selectedOverrideFields : [],
+				unlockFields: mode === "unlock" ? selectedOverrideFields : [],
+			});
+
+			setOverrideFields(result.adminOverriddenFields);
+			setSelectedOverrideFields([]);
+			setMessage(
+				`override ${mode === "lock" ? "lock" : "unlock"} 완료: ${JSON.stringify(result)}`,
+			);
+		} catch {
+			setMessage("override 변경 요청에 실패했습니다.");
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
 	const handleSyncFile = async () => {
 		if (!selectedFile) {
 			setMessage("업로드할 JSON 파일을 선택해주세요.");
@@ -262,7 +360,17 @@ export default function AdminEventsPage() {
 	];
 
 	return (
-		<main style={{ maxWidth: 1080, margin: "0 auto", padding: 24 }}>
+		<main
+			style={{
+				width: "100vw",
+				height: "100dvh",
+				overflowY: "auto",
+				boxSizing: "border-box",
+				maxWidth: 1080,
+				margin: "0 auto",
+				padding: 24,
+			}}
+		>
 			<h1>행샤 어드민</h1>
 
 			<section style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
@@ -287,6 +395,10 @@ export default function AdminEventsPage() {
 				<button type="button" onClick={handleDeleteAll} disabled={isLoading}>
 					전체 삭제
 				</button>
+
+				<button type="button" onClick={handleCreate} disabled={isLoading}>
+					신규 생성
+				</button>
 			</section>
 
 			<section style={{ marginTop: 20 }}>
@@ -308,6 +420,51 @@ export default function AdminEventsPage() {
 				>
 					sync-file 업로드
 				</button>
+			</section>
+
+			<section style={{ marginTop: 20 }}>
+				<h2>adminOverriddenFields lock/unlock</h2>
+
+				<p style={{ margin: "8px 0" }}>
+					마지막 응답 기준 lock: {overrideFields.length > 0 ? overrideFields.join(", ") : "없음"}
+				</p>
+
+				<div
+					style={{
+						display: "grid",
+						gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+						gap: 8,
+					}}
+				>
+					{OVERRIDABLE_FIELDS.map(({ key, label }) => (
+						<label key={key} style={{ display: "flex", gap: 6 }}>
+							<input
+								type="checkbox"
+								checked={selectedOverrideFields.includes(key)}
+								onChange={() => toggleOverrideField(key)}
+							/>
+							{label} ({key})
+						</label>
+					))}
+				</div>
+
+				<div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+					<button
+						type="button"
+						onClick={() => handleUpdateOverrides("lock")}
+						disabled={isLoading}
+					>
+						선택 필드 lock
+					</button>
+
+					<button
+						type="button"
+						onClick={() => handleUpdateOverrides("unlock")}
+						disabled={isLoading}
+					>
+						선택 필드 unlock
+					</button>
+				</div>
 			</section>
 
 			{message && <p style={{ marginTop: 16 }}>{message}</p>}


### PR DESCRIPTION
<img width="653" height="589" alt="image" src="https://github.com/user-attachments/assets/5da94910-b6eb-4778-ba8e-96a00ad40b8c" />

어드민 페이지: 행사 create / adminOverridenFields lock/unlock (PATCH /{eventId}/overrides) 추가

cf) adminOverridenFields -> 어드민 페이지에서 수정한 field를 lock해서, 향후 크롤링에 수정되지 않게 하는 것