### PR TITLE
fix: restore ensureGtag return value to fix TypeScript build error

### DIFF
--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -18,12 +18,14 @@ const ensureDataLayer = () => {
 
 const ensureGtag = () => {
 	if (typeof window.gtag === "function") {
-		return;
+		return window.gtag;
 	}
 
 	window.gtag = function gtag(...args: unknown[]) {
 		window.dataLayer?.push(args);
 	};
+
+	return window.gtag;
 };
 
 const loadGtagScript = (measurementId: string) => {
@@ -48,14 +50,14 @@ export const initGA4 = () => {
 	const measurementId = getMeasurementId();
 
 	ensureDataLayer();
-	ensureGtag();
+	const gtag = ensureGtag();
 	loadGtagScript(measurementId);
 
-	window.gtag("js", new Date());
-	window.gtag("config", measurementId, {
+	gtag("js", new Date());
+	gtag("config", measurementId, {
 		send_page_view: false,
 	});
-	window.gtag("set", "user_properties", DEFAULT_USER_PROPERTIES);
+	gtag("set", "user_properties", DEFAULT_USER_PROPERTIES);
 
 	initialized = true;
 };


### PR DESCRIPTION
## 📝 작업 내용

ensureGtag() was missing return statements, causing its inferred return type to be void and breaking the gtag("js"/"config"/"set") calls in initGA4.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
