### PR TITLE
fix: use arguments object in gtag stub to match gtag.js expectations

### DIFF
--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -21,8 +21,10 @@ const ensureGtag = () => {
 		return window.gtag;
 	}
 
-	window.gtag = function gtag(...args: unknown[]) {
-		window.dataLayer?.push(args);
+	window.gtag = function gtag(_command, _target, _params) {
+		// gtag.js requires Arguments objects (not plain arrays) to recognize commands.
+		// eslint-disable-next-line prefer-rest-params
+		window.dataLayer?.push(arguments);
 	};
 
 	return window.gtag;


### PR DESCRIPTION
## 📝 작업 내용

gtag.js processes dataLayer items as gtag commands only when they are Arguments objects, not plain arrays. The previous rest-params stub (...args) pushed plain arrays which gtag.js silently ignored, causing no g/collect requests to be made and no data reaching GA4.

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
