### PR TITLE
Refresh request에서 토큰 인식 문제 수정

### DIFF
--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -56,6 +56,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 	 * INIT : check for existing session on page load
 	 */
 	useEffect(() => {
+		if (window.location.pathname === '/auth/callback') {
+        	setIsLoading(false);
+        	return;
+    	}
 		const initAuth = async () => {
 			try {
 				const restoredUser = await auth.refresh();


### PR DESCRIPTION
Refresh request에서 initAuth가 401 에러 뱉는 문제 수정

## #️⃣ 연관된 이슈

> SocialLogin

## 📝 작업 내용

> Refresh request에서 토큰 인식 문제 수정

## ✅ 체크리스트
- [ ✅ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
