### PR TITLE
프론트 QA 사항 수정

### DIFF
--- a/src/pages/auth/Login/Login.tsx
+++ b/src/pages/auth/Login/Login.tsx
@@ -27,7 +27,7 @@ export default function Login() {
 		try {
 			await login(email, password);
 			setCheck(true);
-			navigate("/auth/complete");
+			navigate("/main");
 		} catch {
 			setCheck(false);
 		}

--- a/src/pages/auth/Login/Login.tsx
+++ b/src/pages/auth/Login/Login.tsx
@@ -75,7 +75,7 @@ export default function Login() {
 						<span className={styles.loginSignupText}>
 							회원가입을 하시겠어요?
 						</span>
-						<Link to="/auth/signup" className={styles.loginSignupLink}>
+						<Link to="/auth/signup" className={styles.loginSignupText}>
 							회원가입
 						</Link>
 					</div>

--- a/src/pages/auth/Signup/EmailSignUp.tsx
+++ b/src/pages/auth/Signup/EmailSignUp.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type React from "react";
 import { useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { useAuth } from "@contexts/AuthProvider";
 import CompleteSignUp from "../OnBoarding/CompleteSignUp";
 import Onboarding from "../OnBoarding/Onboarding";
@@ -165,6 +165,12 @@ export default function EmailSignUp() {
 						계정 생성
 					</button>
 				</form>
+				<div className={styles.loginLink}>
+					<p className={styles.loginText}>이미 계정이 있으신가요?</p>
+					<Link to="/auth/login" className={styles.loginText}>
+						로그인하러 가기
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/pages/timetable/TimeTableSidebar.tsx
+++ b/src/pages/timetable/TimeTableSidebar.tsx
@@ -109,6 +109,7 @@ export const TimeTableSidebar = ({
 						<span className={styles.plus} aria-hidden="true">
 							+
 						</span>
+						<span className={styles.toggleText}>새 시간표 추가</span>
 					</button>
 				</div>
 

--- a/src/pages/timetable/TimeTableSidebar.tsx
+++ b/src/pages/timetable/TimeTableSidebar.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthProvider";
 import styles from "../../styles/Sidebar.module.css";
 import type { PatchTimetableRequest, Timetable } from "../../util/types";
+import { SidebarLogoutButton } from "../../widgets/SidebarLogoutButton";
 
 interface TimeTableSidebarProps {
 	timetables: Timetable[];
@@ -221,6 +222,9 @@ export const TimeTableSidebar = ({
 				/>
 				<span>시간표</span>
 			</button>
+			<div className={styles.timetableSidebarLogout}>
+				<SidebarLogoutButton />
+			</div>
 		</div>
 	);
 };

--- a/src/pages/timetable/TimeTableToolbar.tsx
+++ b/src/pages/timetable/TimeTableToolbar.tsx
@@ -31,6 +31,7 @@ const TimeTableToolbar = ({
 }: TimeTableToolbarProps) => {
 	const { user } = useAuth();
 	const navigate = useNavigate();
+	const displayTimetableName = timetableName.trim() || "나의 시간표";
 	const yearOptions =
 		years ??
 		Array.from({ length: 7 }, (_, i) => new Date().getFullYear() - 3 + i);
@@ -78,6 +79,7 @@ const TimeTableToolbar = ({
 						</span>
 					</div>
 					<p className={styles.dateTitle}>{timetableName}</p>
+					<p className={styles.mobileTimetableTitle}>{displayTimetableName}</p>
 					<div className={styles.timetableToggleGroup}>
 						<span className={styles.timetableToggleLabel}>행사 함께 보기</span>
 						<button

--- a/src/styles/EmailSignUp.module.css
+++ b/src/styles/EmailSignUp.module.css
@@ -22,13 +22,13 @@
 
 .header {
 	text-align: center;
-	margin-bottom: 22px;
+	margin-bottom: 54px;
 }
 
 .title {
 	margin: 0;
-	font-size: 20px;
-	font-weight: 800;
+	font-size: 28px;
+	font-weight: 700;
 	letter-spacing: -0.03em;
 	color: #111;
 }
@@ -137,4 +137,26 @@
 .submit:active {
 	transform: translateY(1px);
 	box-shadow: 0 7px 16px rgba(0, 0, 0, 0.12);
+}
+
+
+.loginLink {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 24px;
+}
+.loginText {
+	margin: 0;
+  	border: 0;
+  	background: transparent;
+  	color: #8a8a8a;
+  	font-size: 14px;
+  	font-weight: 500;
+  	cursor: pointer;
+}
+
+.loginText:active {
+  color: #666666;
+  text-decoration: underline;
 }

--- a/src/styles/Login.module.css
+++ b/src/styles/Login.module.css
@@ -24,7 +24,7 @@
 
 /* 타이틀 */
 .loginTitle {
-	margin: 0 0 28px;
+	margin: 0 0 54px;
 	font-size: 28px;
 	font-weight: 700;
 	letter-spacing: -0.02em;
@@ -99,23 +99,23 @@
 
 /* 회원가입 안내 */
 .loginSignup {
-	margin-top: 10px;
 	display: flex;
-	gap: 8px;
 	align-items: center;
-	justify-content: center;
+	gap: 8px;
+	margin-top: 24px;
 }
 
 .loginSignupText {
-	font-size: 12px;
-	color: #777;
+	margin: 0;
+  	border: 0;
+  	background: transparent;
+  	color: #8a8a8a;
+  	font-size: 14px;
+  	font-weight: 500;
+  	cursor: pointer;
 }
 
-.loginSignupLink {
-	font-size: 12px;
-	font-weight: 600;
-	color: #000;
-	cursor: pointer;
-	text-decoration: underline;
-	text-underline-offset: 3px;
+.loginSignupText:active {
+  color: #666666;
+  text-decoration: underline;
 }

--- a/src/styles/Sidebar.module.css
+++ b/src/styles/Sidebar.module.css
@@ -168,14 +168,14 @@ body::-webkit-scrollbar {
 }
 
 .iconBtn {
-  width: 30px;
+  width: 100%;
   height: 30px;
-  border-radius: 10px;
   border: 0;
   background: transparent;
   cursor: pointer;
-  display: grid;
-  place-items: center;
+  display: flex;
+  place-items: left;
+  gap: 10px;
 }
 
 .iconBtn:hover {

--- a/src/styles/Sidebar.module.css
+++ b/src/styles/Sidebar.module.css
@@ -573,6 +573,10 @@ body::-webkit-scrollbar {
   cursor: pointer;
 }
 
+.timetableSidebarLogout {
+  margin-top: auto;
+}
+
 @media (max-width: 992px) {
   .sidebarContainer {
     width: 220px;

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -109,6 +109,10 @@
   padding-left: 5px;
 }
 
+.mobileTimetableTitle {
+  display: none;
+}
+
 .navBtnGroup {
   display: flex;
   align-items: center;
@@ -370,11 +374,17 @@
     display: none;
   }
   .timetableToolbarContainer .dateTitle {
+    display: none;
+  }
+  .timetableToolbarContainer .mobileTimetableTitle {
+    display: block;
     min-width: 0;
+    margin: 0;
     padding-left: 0;
     overflow: hidden;
     font-size: 18px;
     font-weight: 700;
+    color: #111827;
     line-height: 1.25;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/styles/WeekGrid.module.css
+++ b/src/styles/WeekGrid.module.css
@@ -190,3 +190,12 @@
 	color: #333;
 	opacity: 0.85;
 }
+
+.blockLocation {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: #333;
+	opacity: 0.85;
+}

--- a/src/widgets/Sidebar.tsx
+++ b/src/widgets/Sidebar.tsx
@@ -14,6 +14,7 @@ import type { Category } from "@types";
 import { useUserData } from "@/contexts/UserDataContext";
 import { IoIosClose } from "react-icons/io";
 import { CATEGORY_BUTTON_COLORS } from "@/util/constants";
+import { SidebarLogoutButton } from "./SidebarLogoutButton";
 
 export const Sidebar = () => {
 	type FilterType = "status" | "org" | "category";
@@ -26,7 +27,7 @@ export const Sidebar = () => {
 		globalSetter: React.Dispatch<React.SetStateAction<Category[]>>;
 	}
 
-	const { user, logout } = useAuth();
+	const { user } = useAuth();
 	const { excludedKeywords, addExcludedKeyword, deleteExcludedKeyword, excludedKeywordLoading } =
 		useUserData();
 	const { categoryGroups, isLoadingMeta } = useFilter();
@@ -366,18 +367,7 @@ export const Sidebar = () => {
 				/>
 				<span>시간표</span>
 			</button>
-			{user && (
-				<button
-					type="button"
-					onClick={() => {
-						logout();
-						ref?.current?.scrollTo(0, 0);
-					}}
-					className={styles.logout}
-				>
-					로그아웃
-				</button>
-			)}
+			<SidebarLogoutButton onLogout={() => ref.current?.scrollTo(0, 0)} />
 		</div>
 	);
 };

--- a/src/widgets/SidebarLogoutButton.tsx
+++ b/src/widgets/SidebarLogoutButton.tsx
@@ -1,0 +1,25 @@
+import { useAuth } from "@contexts/AuthProvider";
+import styles from "@styles/Sidebar.module.css";
+
+interface SidebarLogoutButtonProps {
+	onLogout?: () => void;
+}
+
+export const SidebarLogoutButton = ({ onLogout }: SidebarLogoutButtonProps) => {
+	const { user, logout } = useAuth();
+
+	if (!user) return null;
+
+	return (
+		<button
+			type="button"
+			onClick={() => {
+				void logout();
+				onLogout?.();
+			}}
+			className={styles.logout}
+		>
+			로그아웃
+		</button>
+	);
+};

--- a/src/widgets/Week/WeekGrid.tsx
+++ b/src/widgets/Week/WeekGrid.tsx
@@ -130,6 +130,8 @@ function DayColumn({
 			{blocks.map((b) => {
 				const { event } = b.raw.resource;
 				const color = CATEGORY_COLORS[event.eventTypeId] || CATEGORY_COLORS[6];
+				const location = event.location?.trim();
+				const shouldShowLocation = location && location !== "-";
 
 				return (
 					<button
@@ -152,6 +154,9 @@ function DayColumn({
 							{formatAmPmFromMinutes(b.startMin)} -{" "}
 							{formatAmPmFromMinutes(b.endMin)}
 						</div>
+						{shouldShowLocation && (
+							<div className={styles.blockLocation}>{location}</div>
+						)}
 					</button>
 				);
 			})}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
1. 모바일에서 아무 시간표도 없을때 '나의 시간표’ 렌더링
<img width="268" height="586" alt="image" src="https://github.com/user-attachments/assets/285be36f-600d-489b-ad11-b96090b488c5" />

2. 사이드 바 시간표 추가 버튼 '+' 옆에 '새 시간표 추가' label 추가
<img width="189" height="65" alt="image" src="https://github.com/user-attachments/assets/74c81aa3-faa3-4203-8dfb-d38216abde8e" />

3. 주별 뷰 미리보기에 단발성 행사 장소 정보 추가
- 행사 블럭의 높이에 따라 장소 표시 여부 변경
- 시간 표시와 동일한 style 적용
<img width="748" height="468" alt="image" src="https://github.com/user-attachments/assets/37c083c0-149a-4659-ab1d-cdd098347771" />

4. 회원가입 페이지에서 다시 로그인 화면으로 가는 진입점 추가
5. 로그인 후에는 그냥 바로 캘린더 페이지 (/main)으로 navigate 
6. 시간표 사이드 바에 로그아웃 버튼 추가
7. 로그인 페이지, 회원가입 페이지 css 통일

## ✅ 체크리스트
- [✅] 로컬에서 정상 동작 확인
- [✅] 기존 기능에 영향 없음
- [✅] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
