### PR TITLE
fix: apply category text colors to weekly period events

### DIFF
--- a/src/widgets/Week/PeriodBar.tsx
+++ b/src/widgets/Week/PeriodBar.tsx
@@ -2,7 +2,11 @@ import { useMemo, useCallback } from "react";
 import type { Event, CalendarEvent } from "@/util/types";
 import { clampDate, dayIndexFromWeekStart } from "@/util/weekly_timetable/time";
 import styles from "@styles/PeriodBar.module.css";
-import { CATEGORY_COLORS } from "@/util/constants";
+import {
+	CATEGORY_COLORS,
+	CATEGORY_OTHER_INDEX,
+	CATEGORY_TEXT_COLORS,
+} from "@/util/constants";
 import type { CSSProperties } from "react";
 
 type Props = {
@@ -149,7 +153,11 @@ export function PeriodBars({
 				const displayTitle = truncate40(b.title);
 
 				const categoryId = b.raw.resource.event.eventTypeId;
-				const color = CATEGORY_COLORS[categoryId] ?? "#999";
+				const lineColor =
+					CATEGORY_COLORS[categoryId] ?? CATEGORY_COLORS[CATEGORY_OTHER_INDEX];
+				const textColor =
+					CATEGORY_TEXT_COLORS[categoryId] ??
+					CATEGORY_TEXT_COLORS[CATEGORY_OTHER_INDEX];
 
 				const style: CSSVarStyle = {
 					left: `${leftPct}px`,
@@ -157,8 +165,8 @@ export function PeriodBars({
 					bottom: b.lane * (laneHeight + laneGap),
 					height: laneHeight,
 
-					"--period-line": color,
-					"--period-text": color,
+					"--period-line": lineColor,
+					"--period-text": textColor,
 				};
 
 				return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
주별 뷰 기간제 행사 text 색 월별뷰의 행사 text 색으로 적용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## ✅ 체크리스트
- [✅] 로컬에서 정상 동작 확인
- [✅] 기존 기능에 영향 없음
- [✅] 테스트 통과 (또는 테스트 없음)
- [✅] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)
<img width="586" height="149" alt="image" src="https://github.com/user-attachments/assets/fd1bb004-2a6e-4001-9ecf-2eaee819ac50" />
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
