### PR TITLE
시간표 QA 사항 및 주별뷰 period bar 효과 추가

### DIFF
--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -119,128 +119,137 @@ export function AddClassPanel({
 	};
 
 	return (
-		<aside className={styles.panel}>
-			<SlArrowRight onClick={() => setIsClicked(false)} />
-			<h2>새 수업 추가</h2>
+		<>
+			<button
+				type="button"
+				className={styles.addClassPanelDim}
+				aria-label="수업 추가 닫기"
+				onClick={() => setIsClicked(false)}
+			/>
 
-			<label className={styles.field}>
-				<div>과목명 (필수)</div>
-				<input
-					value={title}
-					onChange={(e) => setTitle(e.target.value)}
-					placeholder="경제학개론"
-				/>
-			</label>
+			<aside className={styles.panel}>
+				<SlArrowRight onClick={() => setIsClicked(false)} />
+				<h2>새 수업 추가</h2>
 
-			<label className={styles.field}>
-				<div>교수명 (선택)</div>
-				<input
-					value={professor}
-					onChange={(e) => setProfessor(e.target.value)}
-					placeholder="박이택"
-				/>
-			</label>
+				<label className={styles.field}>
+					<div>과목명 (필수)</div>
+					<input
+						value={title}
+						onChange={(e) => setTitle(e.target.value)}
+						placeholder="경제학개론"
+					/>
+				</label>
 
-			<label className={styles.field}>
-				<div>학점 (선택)</div>
-				<input
-					type="number"
-					value={credit ?? ""}
-					onChange={(e) => {
-						const value = e.target.value;
-						setCredit(value === "" ? undefined : Number(value));
-					}}
-					placeholder="3"
-					min={0}
-					step={1}
-				/>
-			</label>
+				<label className={styles.field}>
+					<div>교수명 (선택)</div>
+					<input
+						value={professor}
+						onChange={(e) => setProfessor(e.target.value)}
+						placeholder="박이택"
+					/>
+				</label>
 
-			<div>
+				<label className={styles.field}>
+					<div>학점 (선택)</div>
+					<input
+						type="number"
+						value={credit ?? ""}
+						onChange={(e) => {
+							const value = e.target.value;
+							setCredit(value === "" ? undefined : Number(value));
+						}}
+						placeholder="3"
+						min={0}
+						step={1}
+					/>
+				</label>
+
 				<div>
-					<div>시간 (필수)</div>
+					<div>
+						<div>시간 (필수)</div>
+					</div>
+
+					{slot.map((t) => (
+						<div key={t.rowId}>
+							<div className={styles.timeslotDelete}>
+								<TiDelete onClick={() => removeRow(t.rowId)} />
+							</div>
+
+							<div className={styles.dayButtons}>
+								{DAYS.map((d) => {
+									const active = dayOfWeekToDay(t.dayOfweek) === d;
+									return (
+										<button
+											key={d}
+											type="button"
+											className={`${styles.dayBtn} ${active ? styles.isActive : ""}`}
+											onClick={() =>
+												updateRow(t.rowId, { dayOfweek: dayToDayOfWeek(d) })
+											}
+										>
+											{DAY_LABELS_KO[d]}
+										</button>
+									);
+								})}
+							</div>
+
+							<div className={styles.timeRange}>
+								<select
+									value={t.startAt}
+									onChange={(e) =>
+										updateRow(t.rowId, { startAt: Number(e.target.value) })
+									}
+								>
+									{timeOptions.map((o) => (
+										<option key={o.value} value={o.value}>
+											{o.label}
+										</option>
+									))}
+								</select>
+
+								<span className={styles.tilde}>~</span>
+
+								<select
+									value={t.endAt}
+									onChange={(e) =>
+										updateRow(t.rowId, { endAt: Number(e.target.value) })
+									}
+								>
+									{timeOptions.map((o) => (
+										<option key={o.value} value={o.value}>
+											{o.label}
+										</option>
+									))}
+								</select>
+							</div>
+						</div>
+					))}
+
+					<button className={styles.link} type="button" onClick={addRow}>
+						+ 시간 추가
+					</button>
+
+					{!isTimeRangeValid && (
+						<div className={styles.error}>
+							시간 범위가 잘못되었습니다. (종료가 시작보다 늦어야 하고 5분
+							단위여야 합니다.)
+						</div>
+					)}
+
+					{!isTitleValid && (
+						<div className={styles.error}>과목 이름은 필수입니다.</div>
+					)}
 				</div>
 
-				{slot.map((t) => (
-					<div key={t.rowId}>
-						<div className={styles.timeslotDelete}>
-							<TiDelete onClick={() => removeRow(t.rowId)} />
-						</div>
-
-						<div className={styles.dayButtons}>
-							{DAYS.map((d) => {
-								const active = dayOfWeekToDay(t.dayOfweek) === d;
-								return (
-									<button
-										key={d}
-										type="button"
-										className={`${styles.dayBtn} ${active ? styles.isActive : ""}`}
-										onClick={() =>
-											updateRow(t.rowId, { dayOfweek: dayToDayOfWeek(d) })
-										}
-									>
-										{DAY_LABELS_KO[d]}
-									</button>
-								);
-							})}
-						</div>
-
-						<div className={styles.timeRange}>
-							<select
-								value={t.startAt}
-								onChange={(e) =>
-									updateRow(t.rowId, { startAt: Number(e.target.value) })
-								}
-							>
-								{timeOptions.map((o) => (
-									<option key={o.value} value={o.value}>
-										{o.label}
-									</option>
-								))}
-							</select>
-
-							<span className={styles.tilde}>~</span>
-
-							<select
-								value={t.endAt}
-								onChange={(e) =>
-									updateRow(t.rowId, { endAt: Number(e.target.value) })
-								}
-							>
-								{timeOptions.map((o) => (
-									<option key={o.value} value={o.value}>
-										{o.label}
-									</option>
-								))}
-							</select>
-						</div>
-					</div>
-				))}
-
-				<button className={styles.link} type="button" onClick={addRow}>
-					+ 시간 추가
+				<button
+					className={styles.save}
+					type="button"
+					disabled={!canSave}
+					onClick={handleSave}
+				>
+					저장
 				</button>
-
-				{!isTimeRangeValid && (
-					<div className={styles.error}>
-						시간 범위가 잘못되었습니다. (종료가 시작보다 늦어야 하고 5분
-						단위여야 합니다.)
-					</div>
-				)}
-
-				{!isTitleValid && (
-					<div className={styles.error}>과목 이름은 필수입니다.</div>
-				)}
-			</div>
-
-			<button
-				className={styles.save}
-				type="button"
-				disabled={!canSave}
-				onClick={handleSave}
-			>
-				저장
-			</button>
-		</aside>
+			</aside>
+		</>
 	);
 }

--- a/src/pages/timetable/MobileTimetableSidebar.tsx
+++ b/src/pages/timetable/MobileTimetableSidebar.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState } from "react";
+import { SlArrowRight } from "react-icons/sl";
+import Modal from "@/widgets/Modal";
+import type {
+	CreateTimetableRequest,
+	PatchTimetableRequest,
+	Semester,
+	Timetable,
+} from "../../util/types";
+import styles from "@styles/Timetable.module.css";
+
+type NameModalMode = "create" | "rename";
+
+type Props = {
+	isOpen: boolean;
+	timetables: Timetable[];
+	currentTimetable: Timetable | null;
+	year: number;
+	semester: Semester;
+	onClose: () => void;
+	onAddTimetable: (body: CreateTimetableRequest) => Promise<void> | void;
+	onSelectTimetable: (timetable: Timetable) => void;
+	onRename: (
+		timetableId: number,
+		body: PatchTimetableRequest,
+	) => Promise<void> | void;
+	onDelete: (timetableId: number) => Promise<void> | void;
+};
+
+export function MobileTimetableSidebar({
+	isOpen,
+	timetables,
+	currentTimetable,
+	year,
+	semester,
+	onClose,
+	onAddTimetable,
+	onSelectTimetable,
+	onRename,
+	onDelete,
+}: Props) {
+	const [nameModalMode, setNameModalMode] = useState<NameModalMode | null>(
+		null,
+	);
+	const [selectedTimetableForEdit, setSelectedTimetableForEdit] =
+		useState<Timetable | null>(null);
+	const [nameInput, setNameInput] = useState("");
+	const [deleteTarget, setDeleteTarget] = useState<Timetable | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) {
+			setNameModalMode(null);
+			setSelectedTimetableForEdit(null);
+			setNameInput("");
+			setDeleteTarget(null);
+		}
+	}, [isOpen]);
+
+	if (!isOpen) return null;
+
+	const openCreateModal = () => {
+		setSelectedTimetableForEdit(null);
+		setNameInput("");
+		setNameModalMode("create");
+	};
+
+	const openRenameModal = (timetable: Timetable) => {
+		setSelectedTimetableForEdit(timetable);
+		setNameInput(timetable.name ?? "");
+		setNameModalMode("rename");
+	};
+
+	const closeNameModal = () => {
+		setNameModalMode(null);
+		setSelectedTimetableForEdit(null);
+		setNameInput("");
+	};
+
+	const submitNameModal = async () => {
+		const nextName = nameInput.trim();
+		if (!nextName) return;
+
+		if (nameModalMode === "create") {
+			await onAddTimetable({ year, semester, name: nextName });
+		}
+
+		if (nameModalMode === "rename" && selectedTimetableForEdit) {
+			await onRename(selectedTimetableForEdit.id, { name: nextName });
+		}
+
+		closeNameModal();
+	};
+
+	const confirmDelete = async () => {
+		if (!deleteTarget) return;
+		await onDelete(deleteTarget.id);
+		setDeleteTarget(null);
+	};
+
+	return (
+		<>
+			<button
+				type="button"
+				className={styles.mobileTimetableSidebarDim}
+				aria-label="시간표 변경 닫기"
+				onClick={onClose}
+			/>
+
+			<aside className={styles.mobileTimetableSidebar}>
+				<button
+					type="button"
+					className={styles.mobileTimetableSidebarClose}
+					onClick={onClose}
+					aria-label="시간표 변경 닫기"
+				>
+					<SlArrowRight />
+				</button>
+
+				<div className={styles.mobileTimetableSidebarHeader}>
+					<h2>나의 시간표</h2>
+					<button
+						type="button"
+						className={styles.mobileTimetableAddIcon}
+						onClick={openCreateModal}
+						aria-label="새 시간표 추가"
+					>
+						+
+					</button>
+				</div>
+
+				{timetables.length === 0 ? (
+					<p className={styles.mobileTimetableEmpty}>
+						시간표 변경에서 새 시간표를 추가해 주세요
+					</p>
+				) : (
+					<ul className={styles.mobileTimetableList}>
+						{timetables.map((timetable) => {
+							const isSelected = currentTimetable?.id === timetable.id;
+							return (
+								<li
+									key={timetable.id}
+									className={`${styles.mobileTimetableItem} ${
+										isSelected ? styles.mobileTimetableItemSelected : ""
+									}`}
+								>
+									<button
+										type="button"
+										className={styles.mobileTimetableSelect}
+										onClick={() => {
+											onSelectTimetable(timetable);
+											onClose();
+										}}
+									>
+										<span className={styles.mobileTimetableName}>
+											{timetable.name || "이름 없는 시간표"}
+										</span>
+									</button>
+
+									<div className={styles.mobileTimetableActions}>
+										<button
+											type="button"
+											className={styles.mobileTimetableEditButton}
+											onClick={() => openRenameModal(timetable)}
+										>
+											수정
+										</button>
+										<button
+											type="button"
+											className={styles.mobileTimetableDeleteButton}
+											onClick={() => setDeleteTarget(timetable)}
+										>
+											삭제
+										</button>
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</aside>
+
+			{nameModalMode && (
+				<Modal
+					content={
+						nameModalMode === "create"
+							? "새 시간표 이름을 입력해 주세요."
+							: "변경할 시간표 이름을 입력해 주세요."
+					}
+					leftText="확인"
+					rightText="취소"
+					onLeftClick={() => void submitNameModal()}
+					onRightClick={closeNameModal}
+					onClose={closeNameModal}
+				>
+					<input
+						className={styles.mobileTimetableNameInput}
+						value={nameInput}
+						onChange={(event) => setNameInput(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+								void submitNameModal();
+							}
+						}}
+						placeholder="시간표 이름"
+					/>
+				</Modal>
+			)}
+
+			{deleteTarget && (
+				<Modal
+					content={`'${deleteTarget.name || "이름 없는 시간표"}' 시간표를 삭제할까요?`}
+					leftText="삭제"
+					rightText="취소"
+					onLeftClick={() => void confirmDelete()}
+					onRightClick={() => setDeleteTarget(null)}
+					onClose={() => setDeleteTarget(null)}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/pages/timetable/TimeTableSidebar.tsx
+++ b/src/pages/timetable/TimeTableSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FaAnglesLeft, FaAnglesRight } from "react-icons/fa6";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthProvider";
@@ -29,6 +29,7 @@ export const TimeTableSidebar = ({
 	const [editingId, setEditingId] = useState<number | null>(null);
 	const [newName, setNewName] = useState("");
 	const [nameChangeId, setNameChangeId] = useState<number | null>(null);
+	const activePanelRef = useRef<HTMLLIElement | null>(null);
 
 	const navigate = useNavigate();
 
@@ -44,10 +45,10 @@ export const TimeTableSidebar = ({
 	const handleTimetableClick = () => {
 		navigate("/timetable");
 	};
-	
+
 	const handleBookmarkClick = () => {
 		navigate("/bookmark");
-	}
+	};
 
 	const startRename = (tt: Timetable) => {
 		setNameChangeId(tt.id);
@@ -55,10 +56,10 @@ export const TimeTableSidebar = ({
 		setNewName(tt.name ?? "");
 	};
 
-	const cancelRename = () => {
+	const cancelRename = useCallback(() => {
 		setNameChangeId(null);
 		setNewName("");
-	};
+	}, []);
 
 	const applyRename = async (ttId: number) => {
 		const name = newName.trim();
@@ -67,6 +68,25 @@ export const TimeTableSidebar = ({
 		cancelRename();
 		setEditingId(null);
 	};
+
+	useEffect(() => {
+		if (editingId === null && nameChangeId === null) return;
+
+		const handlePointerDown = (event: PointerEvent) => {
+			const activePanel = activePanelRef.current;
+			if (!activePanel) return;
+			if (activePanel.contains(event.target as Node)) return;
+
+			setEditingId(null);
+			cancelRename();
+		};
+
+		document.addEventListener("pointerdown", handlePointerDown);
+
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDown);
+		};
+	}, [editingId, nameChangeId, cancelRename]);
 
 	if (!isOpen) {
 		return (
@@ -120,7 +140,15 @@ export const TimeTableSidebar = ({
 
 				<ul className={styles.list}>
 					{timetables.map((tt) => (
-						<li key={tt.id} className={styles.listItem}>
+						<li
+							key={tt.id}
+							className={styles.listItem}
+							ref={
+								editingId === tt.id || nameChangeId === tt.id
+									? activePanelRef
+									: null
+							}
+						>
 							{nameChangeId === tt.id ? (
 								<div className={styles.renameBox}>
 									<input
@@ -132,7 +160,7 @@ export const TimeTableSidebar = ({
 												onRename(tt.id, { name: newName });
 											}
 											if (e.key === "Escape") {
-												setEditingId(null);
+												cancelRename();
 											}
 										}}
 									></input>
@@ -206,10 +234,10 @@ export const TimeTableSidebar = ({
 				/>
 				<span>캘린더로 돌아가기</span>
 			</button>
-			<button 
+			<button
 				type="button"
 				className={styles.pageLink}
-					onClick={() => handleBookmarkClick()}
+				onClick={() => handleBookmarkClick()}
 			>
 				<img
 					className={styles.icon}

--- a/src/pages/timetable/TimeTableSidebar.tsx
+++ b/src/pages/timetable/TimeTableSidebar.tsx
@@ -157,7 +157,7 @@ export const TimeTableSidebar = ({
 										onChange={(e) => setNewName(e.target.value)}
 										onKeyDown={(e) => {
 											if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-												onRename(tt.id, { name: newName });
+												void applyRename(tt.id);
 											}
 											if (e.key === "Escape") {
 												cancelRename();

--- a/src/pages/timetable/TimeTableToolbar.tsx
+++ b/src/pages/timetable/TimeTableToolbar.tsx
@@ -15,6 +15,7 @@ interface TimeTableToolbarProps {
 	onToggleChange: (isToggleOn: boolean) => void;
 	isLoading?: boolean;
 	years?: number[];
+	hasTimetable?: boolean;
 }
 
 const TimeTableToolbar = ({
@@ -28,6 +29,7 @@ const TimeTableToolbar = ({
 	onToggleChange,
 	isLoading = false,
 	years,
+	hasTimetable = false,
 }: TimeTableToolbarProps) => {
 	const { user } = useAuth();
 	const navigate = useNavigate();
@@ -80,6 +82,7 @@ const TimeTableToolbar = ({
 					</div>
 					<p className={styles.dateTitle}>{timetableName}</p>
 					<p className={styles.mobileTimetableTitle}>{displayTimetableName}</p>
+					{hasTimetable ?
 					<div className={styles.timetableToggleGroup}>
 						<span className={styles.timetableToggleLabel}>행사 함께 보기</span>
 						<button
@@ -93,7 +96,8 @@ const TimeTableToolbar = ({
 						>
 							<span className={styles.timetableToggleThumb} />
 						</button>
-					</div>
+					</div> : null
+					}
 				</div>
 
 				<div className={styles.profileRow}>

--- a/src/pages/timetable/TimetableGrid.tsx
+++ b/src/pages/timetable/TimetableGrid.tsx
@@ -74,7 +74,8 @@ export function TimetableGrid({
 	const hourMarks = useMemo(() => {
 		const list: { hour: number; top: number; label: string }[] = [];
 		for (let h = config.startHour; h <= config.endHour; h++) {
-			const top = (h * 60 - config.startHour * 60) * config.ppm + config.ppm*15;
+			const top =
+				(h * 60 - config.startHour * 60) * config.ppm + config.ppm * 15;
 			const labelHour = isMobile
 				? String(h % 12 || 12)
 				: formatAmPmFromMinutes(h * 60);
@@ -227,6 +228,8 @@ function DayColumn<T>({
 			{eventBlocks.map((b) => {
 				const { event } = b.raw.resource;
 				const color = CATEGORY_COLORS[event.eventTypeId] || CATEGORY_COLORS[6];
+				const location = event.location?.trim();
+				const shouldShowLocation = location && location !== "-";
 
 				return (
 					<button
@@ -249,6 +252,9 @@ function DayColumn<T>({
 							{formatAmPmFromMinutes(b.startMin)} -{" "}
 							{formatAmPmFromMinutes(b.endMin)}
 						</div>
+						{shouldShowLocation && (
+							<div className={styles.eventBlockLocation}>{location}</div>
+						)}
 					</button>
 				);
 			})}

--- a/src/pages/timetable/TimetablePage.tsx
+++ b/src/pages/timetable/TimetablePage.tsx
@@ -21,6 +21,7 @@ import styles from "@styles/Timetable.module.css";
 import { SlArrowLeft } from "react-icons/sl";
 import { TimeTableSidebar } from "./TimeTableSidebar";
 import TimeTableToolbar from "./TimeTableToolbar";
+import { MobileTimetableSidebar } from "./MobileTimetableSidebar";
 import BottomNav from "@/widgets/BottomNav";
 import { useAuth } from "@/contexts/AuthProvider";
 import { useNavigate } from "react-router-dom";
@@ -59,6 +60,8 @@ export default function TimetablePage() {
 	const [tableName, setTableName] = useState<string>("");
 	const [isAddClassPanelOpen, setIsAddClassPanelOpen] = useState(false);
 	const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+	const [isMobileTimetableSidebarOpen, setIsMobileTimetableSidebarOpen] =
+		useState(false);
 	const [isTimetableSimplified, setIsTimetableSimplified] = useState(false);
 	const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
@@ -177,6 +180,16 @@ export default function TimetablePage() {
 			);
 	}, [weekViewData]);
 
+	const openAddClassPanel = () => {
+		setIsMobileTimetableSidebarOpen(false);
+		setIsAddClassPanelOpen(true);
+	};
+
+	const openMobileTimetableSidebar = () => {
+		setIsAddClassPanelOpen(false);
+		setIsMobileTimetableSidebarOpen(true);
+	};
+
 	return (
 		<div
 			className={`${styles.page} ${
@@ -219,10 +232,9 @@ export default function TimetablePage() {
 								왼쪽 사이드바에서 시간표를 추가하거나 선택해 주세요.
 							</span>
 							<span className={styles.emptyMobile}>
-								시간표는 데스크탑 뷰에서 설정해주세요!
+								시간표 변경에서 새 시간표를 추가해 주세요
 							</span>
 						</div>
-						
 					</div>
 				) : (
 					<TimetableGrid
@@ -238,11 +250,19 @@ export default function TimetablePage() {
 				)}
 			</main>
 
+			<button
+				type="button"
+				className={styles.changeTimetableButton}
+				onClick={openMobileTimetableSidebar}
+			>
+				시간표 변경
+			</button>
+
 			{hasTimetable && !isAddClassPanelOpen && (
 				<button
 					type="button"
 					className={styles.addButton}
-					onClick={() => setIsAddClassPanelOpen(true)}
+					onClick={openAddClassPanel}
 				>
 					<SlArrowLeft /> 수업 추가
 				</button>
@@ -259,7 +279,20 @@ export default function TimetablePage() {
 				/>
 			)}
 
-			{!user &&
+			<MobileTimetableSidebar
+				isOpen={isMobileTimetableSidebarOpen}
+				timetables={timetables}
+				currentTimetable={currentTimetable}
+				year={year}
+				semester={semester}
+				onClose={() => setIsMobileTimetableSidebarOpen(false)}
+				onAddTimetable={createTimetable}
+				onSelectTimetable={selectTimetable}
+				onRename={updateTimetableName}
+				onDelete={deleteTimetable}
+			/>
+
+			{!user && (
 				<div className={styles.notFound}>
 					<Modal
 						content={"시간표 페이지 이용을 위해서는\n로그인이 필요해요."}
@@ -268,7 +301,7 @@ export default function TimetablePage() {
 						onClose={null}
 					/>
 				</div>
-			}
+			)}
 
 			{isLoginModalOpen && (
 				<Modal

--- a/src/pages/timetable/TimetablePage.tsx
+++ b/src/pages/timetable/TimetablePage.tsx
@@ -220,6 +220,7 @@ export default function TimetablePage() {
 					onToggleChange={setIsTimetableSimplified}
 					isLoading={isLoading}
 					years={years}
+					hasTimetable={hasTimetable}
 				/>
 
 				{!hasTimetable ? (
@@ -232,7 +233,10 @@ export default function TimetablePage() {
 								왼쪽 사이드바에서 시간표를 추가하거나 선택해 주세요.
 							</span>
 							<span className={styles.emptyMobile}>
-								시간표 변경에서 새 시간표를 추가해 주세요
+								하단 버튼을 클릭해
+							</span>
+						    <span className={styles.emptyMobile}>
+								시간표를 추가하거나 선택해 주세요.
 							</span>
 						</div>
 					</div>

--- a/src/styles/Modal.module.css
+++ b/src/styles/Modal.module.css
@@ -16,6 +16,7 @@
 
   min-width: 300px;
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.05);
+  z-index: 1300;
 }
 
 .modalWrapper {

--- a/src/styles/PeriodBar.module.css
+++ b/src/styles/PeriodBar.module.css
@@ -47,10 +47,22 @@
 	background-color: white;
 	transform: translateY(3px);
 	max-width: 80%;
-	left: 20px;
 	overflow: hidden;
 	border-radius: 999px;
 	transition: font-size 0.2s ease;
+}
+
+.labelLeft {
+	left: 20px;
+}
+
+.labelCenter {
+	left: 50%;
+	transform: translate(-50%, 3px);
+}
+
+.labelRight {
+	right: 20px;
 }
 
 .bar:hover .label {

--- a/src/styles/PeriodBar.module.css
+++ b/src/styles/PeriodBar.module.css
@@ -14,6 +14,13 @@
 	pointer-events: auto;
 	color: var(--period-text, #111);
 	transform: translateY(-10px);
+	transform-origin: center;
+	transition: transform 0.2s ease;
+}
+
+.bar:hover {
+	z-index: 1000;
+	transform: translateY(-10px) scale(1.03);
 }
 
 .line {

--- a/src/styles/PeriodBar.module.css
+++ b/src/styles/PeriodBar.module.css
@@ -45,7 +45,7 @@
 	font-weight: 700;
 	line-height: 1;
 	background-color: white;
-	transform: translateY(-6px);
+	transform: translateY(3px);
 	max-width: 80%;
 	left: 20px;
 	overflow: hidden;

--- a/src/styles/PeriodBar.module.css
+++ b/src/styles/PeriodBar.module.css
@@ -1,7 +1,7 @@
 .container {
 	background: rgba(255, 255, 255, 0.75);
 	padding: 10px;
-	overflow: hidden;
+	overflow: visible;
 }
 
 .bar {
@@ -40,7 +40,7 @@
 	top: 0;
 	display: inline-flex;
 	align-items: center;
-	padding: 10px;
+	padding: 8px;
 	font-size: 14px;
 	font-weight: 700;
 	line-height: 1;
@@ -48,6 +48,18 @@
 	transform: translateY(-6px);
 	max-width: 80%;
 	left: 20px;
+	overflow: hidden;
+	border-radius: 999px;
+	transition: font-size 0.2s ease;
+}
+
+.bar:hover .label {
+	width: fit-content;
+	max-width: none;
+	overflow: visible;
+	font-size: 15px;
+	z-index: 1000;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
 .title {
@@ -56,4 +68,10 @@
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+}
+
+.bar:hover .title {
+	max-width: none;
+	overflow: visible;
+	text-overflow: clip;
 }

--- a/src/styles/Sidebar.module.css
+++ b/src/styles/Sidebar.module.css
@@ -455,7 +455,7 @@ body::-webkit-scrollbar {
   background: #ffffff;
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.05);
 
   display: flex;
   flex-direction: column;

--- a/src/styles/Sidebar.module.css
+++ b/src/styles/Sidebar.module.css
@@ -468,15 +468,15 @@ body::-webkit-scrollbar {
   width: 100%;
   text-align: left;
 
-  padding: 10px 12px;
+  padding: 8px;
   border: none;
-  border-radius: 10px;
+  border-radius: 8px;
 
   background: transparent;
   cursor: pointer;
 
   font-size: var(--fs-md);
-  font-weight: 600;
+  font-weight: 550;
   color: #111;
 }
 
@@ -515,13 +515,14 @@ body::-webkit-scrollbar {
 
   font-size: var(--fs-md);
   border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.15);
+  border: 0.3px solid rgba(0, 0, 0, 0.05);
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.05);
 
   outline: none;
 }
 
 .renameInput:focus {
-  border-color: #111;
+  box-shadow: 0 3px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* 적용 버튼 (입력 아래) */
@@ -532,18 +533,20 @@ body::-webkit-scrollbar {
 
   padding: 0 12px;
   border: none;
-  border-radius: 8px;
+  border-radius: 999px;
 
   font-size: var(--fs-sm);
-  font-weight: 600;
+  font-weight: 550;
 
   background: #111;
+  opacity: 0.8;
   color: #fff;
   cursor: pointer;
 }
 
 .applyButton:hover {
   background: #000;
+  opacity: 1;
 }
 
 .applyButton:active {

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -123,6 +123,10 @@
   padding: 16px;
 }
 
+.addClassPanelDim {
+  display: none;
+}
+
 .panelTitle {
   margin: 8px 0 16px;
   font-size: 22px;
@@ -484,6 +488,17 @@
     top: auto;
     bottom: calc(124px + env(safe-area-inset-bottom));
     transform: none;
+  }
+
+  .addClassPanelDim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1190;
+    border: none;
+    padding: 0;
+    background: none;
+    cursor: pointer;
   }
 
   .panel {

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -404,6 +404,15 @@
   opacity: 0.85;
 }
 
+.eventBlockLocation {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: #333;
+  opacity: 0.85;
+}
+
 .notFound {
   display: none;
   justify-content: center;

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -497,7 +497,7 @@
     padding: 18px 20px 22px;
     border-left: 0;
     border-top: 1px solid #f0eff2;
-    border-radius: 20px 20px 0 0;
+    border-radius: 20px 0 0 0px;
     background: #ffffff;
     box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.12);
   }
@@ -681,7 +681,7 @@
     padding: 18px 20px 22px;
     border-left: 0;
     border-top: 1px solid #f0eff2;
-    border-radius: 20px 20px 0 0;
+    border-radius: 20px 0 0 0px;
     background: #ffffff;
     box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.12);
     z-index: 1200;

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -379,7 +379,6 @@
   padding: 8px;
   border: none;
   border-radius: 0;
-  color: #ffffff;
   text-align: left;
   cursor: pointer;
   overflow: hidden;
@@ -394,15 +393,15 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 550;
   line-height: 1.25;
 }
 
 .eventBlockTime {
   margin-top: 4px;
   font-size: 11px;
-  color: inherit;
-  opacity: 0.9;
+  color: #333;
+  opacity: 0.85;
 }
 
 .notFound {

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -51,19 +51,26 @@
   z-index: 1000;
 
   font-weight: 500;
-  color: #e6e6e6;
 
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-width: 110px;
+  justify-content: center;
 
-  padding: 10px 12px;
+  padding: 10px 10px;
   border: none;
-  border-radius: 10px;
+  border-radius: 999px;
   cursor: pointer;
 
-  background: #ff0031;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  color: #ffffff;
+  background: #ff5b7d;
+  box-shadow: 0 8px 24px rgba(255, 91, 125, 0.28);
+}
+
+.addButton svg {
+  width: 13px;
+  height: 13px;
 }
 
 .leftSidebar {
@@ -434,14 +441,14 @@
   }
 
   .addButton {
-    left: 50%;
-    right: auto;
+    left: auto;
+    right: 20px;
     top: auto;
     bottom: calc(76px + env(safe-area-inset-bottom));
-    transform: translateX(-50%);
-    min-width: 132px;
+    transform: none;
+    min-width: 110px;
     justify-content: center;
-    padding: 10px 16px;
+    padding: 10px 10px;
     border-radius: 999px;
     color: #ffffff;
     background: #ff5b7d;

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -346,6 +346,7 @@
 .blockRemove {
   justify-self: end;
   color: #333;
+  opacity: 0.55;
 }
 
 .blockTitle {

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -446,18 +446,6 @@
     top: auto;
     bottom: calc(76px + env(safe-area-inset-bottom));
     transform: none;
-    min-width: 110px;
-    justify-content: center;
-    padding: 10px 10px;
-    border-radius: 999px;
-    color: #ffffff;
-    background: #ff5b7d;
-    box-shadow: 0 8px 24px rgba(255, 91, 125, 0.28);
-  }
-
-  .addButton svg {
-    width: 13px;
-    height: 13px;
   }
 
   .panel {

--- a/src/styles/Timetable.module.css
+++ b/src/styles/Timetable.module.css
@@ -44,7 +44,8 @@
   overflow: auto;
 }
 
-.addButton {
+.addButton,
+.changeTimetableButton {
   position: fixed;
   right: 100px;
   top: 250px;
@@ -71,6 +72,12 @@
 .addButton svg {
   width: 13px;
   height: 13px;
+}
+
+.changeTimetableButton {
+  display: none;
+  background: rgba(0, 192, 232, 0.6);
+  box-shadow: 0 8px 24px rgba(0, 192, 232, 0.24);
 }
 
 .leftSidebar {
@@ -409,6 +416,28 @@
   display: none;
 }
 
+.mobileTimetableSidebarDim {
+  display: none;
+}
+
+.mobileTimetableSidebar {
+  display: none;
+}
+
+.mobileTimetableNameInput {
+  width: min(260px, 72vw);
+  padding: 11px 12px;
+  border: 1px solid #dedede;
+  border-radius: 10px;
+  font-size: 15px;
+  outline: none;
+}
+
+.mobileTimetableNameInput:focus {
+  border-color: rgba(0, 192, 232, 0.7);
+  box-shadow: 0 0 0 3px rgba(0, 192, 232, 0.14);
+}
+
 @media (max-width: 576px) {
   .page,
   .AddClassPanelClosed,
@@ -448,12 +477,21 @@
     transform: none;
   }
 
+  .changeTimetableButton {
+    display: inline-flex;
+    left: auto;
+    right: 20px;
+    top: auto;
+    bottom: calc(124px + env(safe-area-inset-bottom));
+    transform: none;
+  }
+
   .panel {
     position: fixed;
     left: 0;
     right: 0;
     bottom: calc(64px + env(safe-area-inset-bottom));
-    z-index: 110;
+    z-index: 1200;
     max-height: min(72dvh, 620px);
     overflow-y: auto;
     padding: 18px 20px 22px;
@@ -617,5 +655,167 @@
   }
   .emptyMobile {
     display: block;
+  }
+
+  .mobileTimetableSidebarDim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1190;
+    border: none;
+    padding: 0;
+    background: none;
+    cursor: pointer;
+  }
+
+  .mobileTimetableSidebar {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: calc(64px + env(safe-area-inset-bottom));
+    flex-direction: column;
+    max-height: min(72dvh, 620px);
+    overflow-y: auto;
+    padding: 18px 20px 22px;
+    border-left: 0;
+    border-top: 1px solid #f0eff2;
+    border-radius: 20px 20px 0 0;
+    background: #ffffff;
+    box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.12);
+    z-index: 1200;
+  }
+
+  .mobileTimetableSidebarClose {
+    display: inline-flex;
+    width: fit-content;
+    height: fit-content;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    margin: 0 0 8px;
+    border: none;
+    background: transparent;
+    color: #8a8a8a;
+    cursor: pointer;
+  }
+
+  .mobileTimetableSidebarClose svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .mobileTimetableSidebarHeader {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 0;
+    margin: 8px 0 18px;
+  }
+
+  .mobileTimetableSidebarHeader h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: #111111;
+  }
+
+  .mobileTimetableAddIcon {
+    display: inline-flex;
+    width: 28px;
+    height: 28px;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: #777777;
+    font-size: 26px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .mobileTimetableEmpty {
+    margin: 8px 0 0;
+    color: #757575;
+    font-size: 14px;
+    line-height: 1.45;
+    word-break: keep-all;
+  }
+
+  .mobileTimetableList {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .mobileTimetableItem {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    min-height: 64px;
+    padding: 10px;
+    border-radius: 10px;
+    background: transparent;
+  }
+
+  .mobileTimetableItemSelected {
+    background: rgba(0, 192, 232, 0.12);
+  }
+
+  .mobileTimetableSelect {
+    min-width: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .mobileTimetableName {
+    display: block;
+    overflow: hidden;
+    color: #1e1e1e;
+    font-size: 16px;
+    line-height: 1.4;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobileTimetableItem:not(.mobileTimetableItemSelected) .mobileTimetableName {
+    opacity: 0.68;
+  }
+
+  .mobileTimetableActions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .mobileTimetableEditButton,
+  .mobileTimetableDeleteButton {
+    min-width: 54px;
+    height: 36px;
+    padding: 0 14px;
+    border: none;
+    border-radius: 999px;
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .mobileTimetableEditButton {
+    background: rgba(0, 192, 232, 0.6);
+  }
+
+  .mobileTimetableDeleteButton {
+    background: rgba(255, 45, 85, 0.5);
   }
 }

--- a/src/styles/Toolbar.module.css
+++ b/src/styles/Toolbar.module.css
@@ -356,28 +356,42 @@
   }
   .timetableToolbarContainer {
     margin: 0;
-    padding: 82px 20px 0;
-    margin-bottom: 0;
+    padding: 56px 20px 0;
+    margin-bottom: 20px;
     background: #ffffff;
   }
   .timetableToolbarContainer .headerRow {
     align-items: center;
   }
   .timetableToolbarContainer .selectGroup {
+    display: grid;
     flex: 1;
-    gap: 8px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 8px;
   }
   .timetableToolbarContainer .semesterSelectGroup {
-    display: none;
+    display: inline-flex;
+    grid-column: 1 / -1;
+    grid-row: 1;
+    min-width: 0;
   }
   .timetableToolbarContainer .selectWrap {
-    display: none;
+    display: inline-flex;
+    min-width: 0;
+  }
+  .timetableToolbarContainer .select {
+    width: 100%;
+    height: 34px;
+    padding: 0 30px 0 10px;
+    font-size: 13px;
   }
   .timetableToolbarContainer .dateTitle {
     display: none;
   }
   .timetableToolbarContainer .mobileTimetableTitle {
     display: block;
+    grid-column: 1;
+    grid-row: 2;
     min-width: 0;
     margin: 0;
     padding-left: 0;
@@ -390,6 +404,8 @@
     white-space: nowrap;
   }
   .timetableToolbarContainer .timetableToggleGroup {
+    grid-column: 2;
+    grid-row: 2;
     align-items: flex-start;
   }
   .timetableToolbarContainer .timetableToggleLabel {

--- a/src/widgets/Modal.tsx
+++ b/src/widgets/Modal.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import styles from "@styles/Modal.module.css";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { IoIosClose } from "react-icons/io";
@@ -7,8 +8,9 @@ interface ModalProps {
 	leftText: string;
 	rightText?: string | null;
 	onLeftClick: () => void;
-	onRightClick?: (() =>  void) | null;
+	onRightClick?: (() => void) | null;
 	onClose: (() => void) | null;
+	children?: ReactNode;
 }
 
 const Modal = ({
@@ -18,6 +20,7 @@ const Modal = ({
 	onLeftClick,
 	onRightClick,
 	onClose,
+	children,
 }: ModalProps) => {
 	return (
 		<div className={styles.modalContainer}>
@@ -32,25 +35,25 @@ const Modal = ({
 					</button>
 				)}
 				<span className={styles.modalContent}>{content}</span>
+				{children}
 				<div className={styles.buttonsRow}>
 					<button
 						className={`${rightText ? styles.leftBtn : styles.linkBtn}`}
 						type="button"
 						onClick={onLeftClick}
 					>
-						{!rightText && 
-							<FaExternalLinkAlt />
-						}
+						{!rightText && <FaExternalLinkAlt />}
 						<span>{leftText}</span>
 					</button>
-					{rightText && onRightClick &&
-					<button
-						className={styles.rightBtn}
-						type="button"
-						onClick={onRightClick}
-					>
-						{rightText}
-					</button>}
+					{rightText && onRightClick && (
+						<button
+							className={styles.rightBtn}
+							type="button"
+							onClick={onRightClick}
+						>
+							{rightText}
+						</button>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/widgets/Week/PeriodBar.tsx
+++ b/src/widgets/Week/PeriodBar.tsx
@@ -167,6 +167,13 @@ export function PeriodBars({
 					"--period-text": textColor,
 				};
 
+				const labelAlignment =
+					b.startIdx <= 1
+						? styles.labelLeft
+						: b.startIdx >= 5
+							? styles.labelRight
+							: styles.labelCenter;
+
 				return (
 					<button
 						key={String(b.id)}
@@ -178,7 +185,7 @@ export function PeriodBars({
 					>
 						<div className={styles.line} />
 
-						<div className={styles.label}>
+						<div className={`${styles.label} ${labelAlignment}`}>
 							<span className={styles.title}>{b.title}</span>
 						</div>
 					</button>

--- a/src/widgets/Week/PeriodBar.tsx
+++ b/src/widgets/Week/PeriodBar.tsx
@@ -32,6 +32,8 @@ type CSSVarStyle = CSSProperties & {
 	[key: `--${string}`]: string;
 };
 
+const PERIOD_BAR_TOP_HEADROOM = 28;
+
 function startOfWeekSunday(d: Date) {
 	const x = new Date(d);
 	x.setHours(0, 0, 0, 0);
@@ -134,7 +136,10 @@ export function PeriodBars({
 			className={styles.container}
 			style={{
 				bottom: bottomOffset,
-				height: laneCount * laneHeight + Math.max(0, laneCount - 1) * laneGap,
+				height:
+					PERIOD_BAR_TOP_HEADROOM +
+					laneCount * laneHeight +
+					Math.max(0, laneCount - 1) * laneGap,
 				left: left,
 				width: width,
 			}}

--- a/src/widgets/Week/PeriodBar.tsx
+++ b/src/widgets/Week/PeriodBar.tsx
@@ -47,11 +47,6 @@ function endOfWeekSaturday(d: Date) {
 	return end;
 }
 
-function truncate40(s: string) {
-	if (!s) return "";
-	return s.length > 40 ? `${s.slice(0, 40)}…` : s;
-}
-
 function assignLanes(bars: Bar[]) {
 	const lanes: Bar[][] = [];
 	const placed: Array<Bar & { lane: number }> = [];
@@ -150,8 +145,6 @@ export function PeriodBars({
 				const leftPct = b.startIdx * ((width - 80) / 7) + 80;
 				const widthPct = span * ((width - 80) / 7);
 
-				const displayTitle = truncate40(b.title);
-
 				const categoryId = b.raw.resource.event.eventTypeId;
 				const lineColor =
 					CATEGORY_COLORS[categoryId] ?? CATEGORY_COLORS[CATEGORY_OTHER_INDEX];
@@ -181,7 +174,7 @@ export function PeriodBars({
 						<div className={styles.line} />
 
 						<div className={styles.label}>
-							<span className={styles.title}>{displayTitle}</span>
+							<span className={styles.title}>{b.title}</span>
 						</div>
 					</button>
 				);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 모바일 뷰 시간표 추가 사이드바 구현
2. 모바일 뷰 시간표 상단에 년도, 학기 선택 토글 추가
3. 선택된 시간표 없으면 행사 보여주는 토클 없애기
4. 주별 뷰 미리보기도 월별 뷰처럼 호버 시 확장
## ✅ 체크리스트
- [✅] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [✅] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)
<img width="793" height="275" alt="image" src="https://github.com/user-attachments/assets/38198cea-eacd-4ff9-ae88-10b11fd23a3f" />
<img width="285" height="181" alt="image" src="https://github.com/user-attachments/assets/e3d23061-d304-4d40-965c-532623549f31" />
<img width="287" height="553" alt="image" src="https://github.com/user-attachments/assets/005e8b21-38b6-4a12-bfd8-1d059ea87343" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
