### PR TITLE
fix: fix event block overflow error in week view

### DIFF
--- a/src/util/weekly_timetable/layout.ts
+++ b/src/util/weekly_timetable/layout.ts
@@ -93,6 +93,8 @@ export function flattenEventsToBlocks(
 	cfg: GridConfig,
 ): WeekGridBlock[] {
 	const blocks: WeekGridBlock[] = [];
+	const gridStartMin = cfg.startHour * 60;
+	const gridEndMin = cfg.endHour * 60;
 
 	cevents.forEach((cevent, idx) => {
 		const start = cevent.resource.event.eventStart;
@@ -108,14 +110,18 @@ export function flattenEventsToBlocks(
 
 		const startMin = toMinutesOfDay(start);
 		const endMin = toMinutesOfDay(end);
+		const visibleStartMin = Math.max(startMin, gridStartMin);
+		const visibleEndMin = Math.min(endMin, gridEndMin);
+
+		if (visibleEndMin <= visibleStartMin) return;
 
 		blocks.push({
 			blockId: idx,
 			sourceId: cevent.resource.event.id,
 			title: cevent.title,
 			day: toDay(start.getDay()),
-			top: minutesToTop(startMin, cfg),
-			height: durationToHeight(startMin, endMin, cfg),
+			top: minutesToTop(visibleStartMin, cfg),
+			height: durationToHeight(visibleStartMin, visibleEndMin, cfg),
 			startMin,
 			endMin,
 			raw: cevent,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
주별 뷰 오류 해결

> ex) #이슈번호, #이슈번호
#128 
## 📝 작업 내용
주별뷰에서 행사 시작시간, 종료시간을 기준으로 top, height 계산 로직에 오전 7시, 오후 12시로 clamp 하는 로직 추가
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1033" height="498" alt="image" src="https://github.com/user-attachments/assets/28125931-403d-42b5-87af-d129f613d329" />

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
