### PR TITLE
서치페이지를 포함한 DDAY 계산 공통화 및 리팩터링

### DIFF
--- a/src/components/layout/sidePannel/DetailView.tsx
+++ b/src/components/layout/sidePannel/DetailView.tsx
@@ -3,9 +3,10 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styles from "./DetailView.module.css";
 import { getDDay } from "../../../util/Calendar/getDday";
+import { getEventDDayTargetDate } from "@/util/Calendar/getEventDDayTargetDate";
 import { CATEGORY_COLORS, CATEGORY_LIST } from "@constants";
 import { FaAnglesRight, FaLocationDot } from "react-icons/fa6";
-import type { CalendarEvent, EventDetail } from "@types";
+import type { EventDetail } from "@types";
 import parse from "html-react-parser";
 import { sanitizeDetail } from "@/util/sanitizeDetail";
 import { useUserData } from "@/contexts/UserDataContext";
@@ -14,14 +15,10 @@ import { useAuth } from "@/contexts/AuthProvider";
 import DetailMemo from "./DetailMemo";
 import Modal, { ErrorModal } from "../../ui/Modal";
 import Loading from "../../ui/Loading";
-import calendarEventMapper from "@/util/Calendar/calendarEventMapper";
 import EventDate from "../../feature/eventDate/EventDate";
 
 const DetailView = ({ eventId }: { eventId: number }) => {
 	const [event, setEvent] = useState<EventDetail>();
-	const [calendarEvent, setCalendarEvent] = useState<CalendarEvent | null>(
-		event ? calendarEventMapper(event, "day") : null,
-	);
 	const { toggleBookmark } = useUserData();
 	const { fetchEventById, detailError, isLoadingDetail, clearError } =
 		useEvents();
@@ -61,7 +58,6 @@ const DetailView = ({ eventId }: { eventId: number }) => {
 		const loadEvent = async () => {
 			const event = await fetchEventById(eventId);
 			setEvent(event ?? undefined);
-			if (event) setCalendarEvent(calendarEventMapper(event, "day"));
 		};
 		loadEvent();
 		// scroll to top of component
@@ -71,9 +67,7 @@ const DetailView = ({ eventId }: { eventId: number }) => {
 	}, [eventId, fetchEventById]);
 
 	// 디데이 계산할 기준 날짜
-	const ddayTargetDate = calendarEvent?.resource.isPeriodEvent
-		? calendarEvent.end
-		: calendarEvent?.start;
+	const ddayTargetDate = getEventDDayTargetDate(event);
 
 	const [isBookmarked, setIsBookmarked] = useState<boolean>(
 		!!event?.isBookmarked,

--- a/src/components/layout/sidePannel/EventCard.tsx
+++ b/src/components/layout/sidePannel/EventCard.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import styles from "./CardView.module.css";
 import { getDDay } from "@calendarUtil/getDday";
+import { getEventDDayTargetDate } from "@calendarUtil/getEventDDayTargetDate";
 import { CATEGORY_COLORS, CATEGORY_LIST } from "@constants";
 import type { Event } from "@types";
 import { useUserData } from "@/contexts/UserDataContext";
@@ -8,7 +9,7 @@ import { StartDate } from "@/components/feature/eventDate/EventDate";
 import { useAuth } from "@/contexts/AuthProvider";
 
 const MobileChipsList = ({ event }: { event: Event }) => {
-	const ddayTargetDate = event.applyEnd;
+	const ddayTargetDate = getEventDDayTargetDate(event);
 	const [expanded, setExpanded] = useState(false);
 	const timerRef = useRef<number | null>(null);
 
@@ -50,13 +51,14 @@ const MobileChipsList = ({ event }: { event: Event }) => {
 					</span>
 				</button>
 			</li>
+			{/* TODO: 비기간 행사는 행사 시작 D-day라서 '지원' 레이블 유지 여부 확인 필요 */}
 			<span className={styles.ddayTargetDate}>{`지원 ${getDDay(ddayTargetDate)}`}</span>
 		</ul>
 	)
 }
 
 const EventCard = ({ event, onLoginPrompt, fullWidth = false }: { event: Event; onLoginPrompt?: () => void; fullWidth?: boolean; }) => {
-	const ddayTargetDate = event.applyEnd;
+	const ddayTargetDate = getEventDDayTargetDate(event);
 	const {user} = useAuth();
 
 	const [isBookmarked, setIsBookmarked] = useState<boolean>(
@@ -107,6 +109,7 @@ const EventCard = ({ event, onLoginPrompt, fullWidth = false }: { event: Event; 
 				<span className={styles.orgText}>{event.organization}</span>
 			</div>
 			<ul className={styles.chipsList}>
+				{/* TODO: 비기간 행사는 행사 시작 D-day라서 '지원' 레이블 유지 여부 확인 필요 */}
 				<li className={styles.deadlineChip}>{`지원 ${getDDay(ddayTargetDate)}`}</li>
 				<li
 					className={styles.categoryChip}

--- a/src/pages/search/SearchGridItem.tsx
+++ b/src/pages/search/SearchGridItem.tsx
@@ -1,6 +1,7 @@
 import { useState, type KeyboardEvent, type MouseEvent } from "react";
 import { CATEGORY_COLORS, CATEGORY_LIST } from "@/util/constants";
 import { getDDay } from "@/util/Calendar/getDday";
+import { getEventDDayTargetDate } from "@/util/Calendar/getEventDDayTargetDate";
 import type { HighlightSearchItem } from "@/util/types";
 import { useUserData } from "@/contexts/UserDataContext";
 import { useAuth } from "@/contexts/AuthProvider";
@@ -24,7 +25,7 @@ interface GridItemProps {
 const SearchGridItem = ({ item, onClick, onLoginPrompt }: GridItemProps) => {
 	const { event, highlight } = item;
 
-	const dday = getDDay(event.applyEnd);
+	const dday = getDDay(getEventDDayTargetDate(event));
 	const catColor = CATEGORY_COLORS[event.eventTypeId];
 	const dateStr = formatDateRange(event.eventStart, event.eventEnd);
 

--- a/src/pages/search/SearchNewListItem.tsx
+++ b/src/pages/search/SearchNewListItem.tsx
@@ -1,6 +1,7 @@
 import { useState, type KeyboardEvent, type MouseEvent } from "react";
 import { CATEGORY_COLORS, CATEGORY_LIST } from "@/util/constants";
 import { getDDay } from "@/util/Calendar/getDday";
+import { getEventDDayTargetDate } from "@/util/Calendar/getEventDDayTargetDate";
 import type { HighlightSearchItem } from "@/util/types";
 import { useUserData } from "@/contexts/UserDataContext";
 import { useAuth } from "@/contexts/AuthProvider";
@@ -23,7 +24,7 @@ interface ItemProps {
 
 const SearchNewListItem = ({ item, onClick, onLoginPrompt }: ItemProps) => {
 	const { event, highlight } = item;
-	const dday = getDDay(event.applyEnd);
+	const dday = getDDay(getEventDDayTargetDate(event));
 	const catColor = CATEGORY_COLORS[event.eventTypeId];
 	const dateStr = formatDateRange(event.eventStart, event.eventEnd);
 

--- a/src/util/Calendar/getEventDDayTargetDate.ts
+++ b/src/util/Calendar/getEventDDayTargetDate.ts
@@ -1,0 +1,11 @@
+import type { Event } from "@types";
+
+export const getEventDDayTargetDate = (
+	event: Event | undefined,
+): Date | undefined => {
+	if (!event) return undefined;
+
+	return event.isPeriodEvent
+		? event.applyEnd
+		: (event.eventStart ?? event.applyStart);
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#155 

## 📝 작업 내용
- 검색 페이지 QA에서 dday 계산이 잘못됨을 발견
- 기간제/참여형 고려하는 기존 로직을 유틸함수로 묶고, 검색 페이지에 있는 item / DetailView / EventCard가 재사용하도록 변경


## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
