### PR TITLE
시간표 시간 설정 UI 변경

### DIFF
--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -103,11 +103,6 @@ export function AddClassPanel({
 	const canSave = isTimeRangeValid && isTitleValid && !hasConflict;
 
 	const handleSave = () => {
-		const conflict = slot.some((s) => hasOverlap(allSlots, s));
-		if (conflict) {
-			alert("시간이 겹치는 수업은 추가할 수 없습니다.");
-			return;
-		}
 		if (!timetableId) {
 			alert("시간표를 먼저 추가해주세요.");
 			return;
@@ -260,6 +255,9 @@ export function AddClassPanel({
 
 					{!isTitleValid && (
 						<div className={styles.error}>과목 이름은 필수입니다.</div>
+					)}
+					{hasConflict && (
+						<div className={styles.error}>시간이 겹치는 수업이 있습니다.</div>
 					)}
 				</div>
 

--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -17,6 +17,7 @@ import type {
 } from "../../util/types";
 import { DAY_LABELS_KO } from "../../util/types";
 import { buildTimeOptions, STEP_MIN } from "../../util/weekly_timetable/time";
+import { TimeRangePicker, type TimeValue } from "./TimeRangePicker";
 import styles from "./Timetable.module.css";
 
 type Props = {
@@ -25,10 +26,26 @@ type Props = {
 	allSlots: TimeSlot[];
 	year: number;
 	semester: Semester;
+	isMobile: boolean;
 	setIsClicked: (isClicked: boolean) => void;
 };
 
 const DAYS: Day[] = [0, 1, 2, 3, 4, 5, 6];
+
+const minutesToTimeValue = (minutes: number): TimeValue => {
+	const hour = Math.floor(minutes / 60);
+	const minute = minutes % 60;
+
+	return `${String(hour).padStart(2, "0")}:${String(minute).padStart(
+		2,
+		"0",
+	)}` as TimeValue;
+};
+
+const timeValueToMinutes = (time: TimeValue) => {
+	const [hour, minute] = time.split(":").map(Number);
+	return hour * 60 + minute;
+};
 
 export function AddClassPanel({
 	timetableId,
@@ -36,6 +53,7 @@ export function AddClassPanel({
 	allSlots,
 	year,
 	semester,
+	isMobile,
 	setIsClicked,
 }: Props) {
 	const timeOptions = useMemo(() => buildTimeOptions(STEP_MIN), []);
@@ -193,48 +211,61 @@ export function AddClassPanel({
 								})}
 							</div>
 
-							<div className={styles.timeRange}>
-								<select
-									value={t.startAt}
-									onChange={(e) =>
-										updateRow(t.rowId, { startAt: Number(e.target.value) })
+							{isMobile ? (
+								<TimeRangePicker
+									startTime={minutesToTimeValue(t.startAt)}
+									endTime={minutesToTimeValue(t.endAt)}
+									minuteStep={STEP_MIN}
+									onChange={({ startTime, endTime }) =>
+										updateRow(t.rowId, {
+											startAt: timeValueToMinutes(startTime),
+											endAt: timeValueToMinutes(endTime),
+										})
 									}
-								>
-									{timeOptions.map((o) => (
-										<option key={o.value} value={o.value}>
-											{o.label}
-										</option>
-									))}
-								</select>
+								/>
+							) : (
+								<div className={styles.timeRange}>
+									<select
+										aria-label="수업 시작 시간"
+										value={t.startAt}
+										onChange={(e) =>
+											updateRow(t.rowId, {
+												startAt: Number(e.target.value),
+											})
+										}
+									>
+										{timeOptions.map((option) => (
+											<option key={option.value} value={option.value}>
+												{option.label}
+											</option>
+										))}
+									</select>
 
-								<span className={styles.tilde}>~</span>
+									<span className={styles.tilde}>~</span>
 
-								<select
-									value={t.endAt}
-									onChange={(e) =>
-										updateRow(t.rowId, { endAt: Number(e.target.value) })
-									}
-								>
-									{timeOptions.map((o) => (
-										<option key={o.value} value={o.value}>
-											{o.label}
-										</option>
-									))}
-								</select>
-							</div>
+									<select
+										aria-label="수업 종료 시간"
+										value={t.endAt}
+										onChange={(e) =>
+											updateRow(t.rowId, {
+												endAt: Number(e.target.value),
+											})
+										}
+									>
+										{timeOptions.map((option) => (
+											<option key={option.value} value={option.value}>
+												{option.label}
+											</option>
+										))}
+									</select>
+								</div>
+							)}
 						</div>
 					))}
 
 					<button className={styles.link} type="button" onClick={addRow}>
 						+ 시간 추가
 					</button>
-
-					{!isTimeRangeValid && (
-						<div className={styles.error}>
-							시간 범위가 잘못되었습니다. (종료가 시작보다 늦어야 하고 5분
-							단위여야 합니다.)
-						</div>
-					)}
 
 					{!isTitleValid && (
 						<div className={styles.error}>과목 이름은 필수입니다.</div>

--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -18,6 +18,7 @@ import type {
 import { DAY_LABELS_KO } from "../../util/types";
 import { buildTimeOptions, STEP_MIN } from "../../util/weekly_timetable/time";
 import { TimeRangePicker, type TimeValue } from "./TimeRangePicker";
+import { TimeSelect } from "./TimeSelect";
 import styles from "./Timetable.module.css";
 
 type Props = {
@@ -225,39 +226,29 @@ export function AddClassPanel({
 								/>
 							) : (
 								<div className={styles.timeRange}>
-									<select
-										aria-label="수업 시작 시간"
+									<TimeSelect
+										ariaLabel="수업 시작 시간"
 										value={t.startAt}
-										onChange={(e) =>
+										options={timeOptions}
+										onChange={(startAt) =>
 											updateRow(t.rowId, {
-												startAt: Number(e.target.value),
+												startAt,
 											})
 										}
-									>
-										{timeOptions.map((option) => (
-											<option key={option.value} value={option.value}>
-												{option.label}
-											</option>
-										))}
-									</select>
+									/>
 
 									<span className={styles.tilde}>~</span>
 
-									<select
-										aria-label="수업 종료 시간"
+									<TimeSelect
+										ariaLabel="수업 종료 시간"
 										value={t.endAt}
-										onChange={(e) =>
+										options={timeOptions}
+										onChange={(endAt) =>
 											updateRow(t.rowId, {
-												endAt: Number(e.target.value),
+												endAt,
 											})
 										}
-									>
-										{timeOptions.map((option) => (
-											<option key={option.value} value={option.value}>
-												{option.label}
-											</option>
-										))}
-									</select>
+									/>
 								</div>
 							)}
 						</div>

--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -294,6 +294,9 @@ export function AddClassPanel({
 					{hasConflict && (
 						<div className={styles.error}>시간이 겹치는 수업이 있습니다.</div>
 					)}
+					{!isTimeRangeValid && (
+						<div className={styles.error}>종료 시간은 시작 시간보다 늦어야 합니다.</div>
+					)}
 				</div>
 
 				<button

--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -2,18 +2,16 @@ import { useMemo, useRef, useState } from "react";
 import { SlArrowRight } from "react-icons/sl";
 import { TiDelete } from "react-icons/ti";
 import { hasOverlap } from "../../util/weekly_timetable/layout";
-import {
-	dayOfWeekToDay,
-	dayToDayOfWeek,
-} from "../../util/weekly_timetable/time";
+import { dayToDayOfWeek } from "../../util/weekly_timetable/time";
 
 import type {
 	Course,
 	CreateCustomCourseRequest,
 	Day,
+	DayOfWeek,
 	Semester,
-	SlotRow,
 	TimeSlot,
+	MultiDaySlotRow,
 } from "../../util/types";
 import { DAY_LABELS_KO } from "../../util/types";
 import { buildTimeOptions, STEP_MIN } from "../../util/weekly_timetable/time";
@@ -62,22 +60,34 @@ export function AddClassPanel({
 	const [professor, setProfessor] = useState("");
 	const [credit, setCredit] = useState<number | undefined>(undefined);
 
-	const emptyRow = (): SlotRow => ({
+	const emptyRow = (): MultiDaySlotRow => ({
 		rowId: crypto.randomUUID(),
-		dayOfweek: "MON",
+		dayOfweeks: ["MON"],
 		startAt: 8 * 60,
 		endAt: 11 * 60,
 	});
 
-	const [slot, setSlot] = useState<SlotRow[]>([emptyRow()]);
+	const [slot, setSlot] = useState<MultiDaySlotRow[]>([emptyRow()]);
 	const addRow = () => setSlot((prev) => [...prev, emptyRow()]);
 	const removeRow = (rowId: string) =>
 		setSlot((prev) => prev.filter((t) => t.rowId !== rowId));
-	const updateRow = (rowId: string, patch: Partial<SlotRow>) =>
+	const updateRow = (rowId: string, patch: Partial<MultiDaySlotRow>) =>
 		setSlot((prev) =>
 			prev.map((r) =>
-				r.rowId === rowId ? ({ ...r, ...patch } as SlotRow) : r,
+				r.rowId === rowId ? ({ ...r, ...patch } as MultiDaySlotRow) : r,
 			),
+		);
+	const toggleDay = (rowId: string, dayOfweek: DayOfWeek) =>
+		setSlot((prev) =>
+			prev.map((row) => {
+				if (row.rowId !== rowId) return row;
+
+				const dayOfweeks = row.dayOfweeks.includes(dayOfweek)
+					? row.dayOfweeks.filter((day) => day !== dayOfweek)
+					: [...row.dayOfweeks, dayOfweek];
+
+				return { ...row, dayOfweeks };
+			}),
 		);
 
 	const nextIdRef = useRef(0);
@@ -90,6 +100,17 @@ export function AddClassPanel({
 				t.endAt % STEP_MIN === 0,
 		);
 	}, [slot]);
+	const hasSelectedDay = useMemo(
+		() => slot.length > 0 && slot.every((row) => row.dayOfweeks.length > 0),
+		[slot],
+	);
+	const expandedSlots = useMemo(
+		() =>
+			slot.flatMap(({ dayOfweeks, startAt, endAt }) =>
+				dayOfweeks.map((dayOfweek) => ({ dayOfweek, startAt, endAt })),
+			),
+		[slot],
+	);
 
 	const isTitleValid = useMemo(() => {
 		return title.trim().length > 0;
@@ -97,10 +118,14 @@ export function AddClassPanel({
 
 	const hasConflict = useMemo(() => {
 		if (!isTimeRangeValid) return false;
-		return slot.some((s) => hasOverlap(allSlots, s));
-	}, [slot, allSlots, isTimeRangeValid]);
+		return expandedSlots.some(
+			(s, index) =>
+				hasOverlap(allSlots, s) || hasOverlap(expandedSlots.slice(0, index), s),
+		);
+	}, [expandedSlots, allSlots, isTimeRangeValid]);
 
-	const canSave = isTimeRangeValid && isTitleValid && !hasConflict;
+	const canSave =
+		isTimeRangeValid && isTitleValid && hasSelectedDay && !hasConflict;
 
 	const handleSave = () => {
 		if (!timetableId) {
@@ -114,7 +139,7 @@ export function AddClassPanel({
 			semester,
 			courseTitle: title,
 			source: "CUSTOM",
-			timeSlots: slot.map(({ rowId, ...rest }) => rest),
+			timeSlots: expandedSlots,
 			courseNumber: undefined,
 			lectureNumber: undefined,
 			credit,
@@ -187,26 +212,26 @@ export function AddClassPanel({
 						<div key={t.rowId}>
 							<div className={styles.timeslotDelete}>
 								<button
-								type="button"
-								className={styles.deleteBtn}
-								aria-label="시간 삭제"
-								onClick={() => removeRow(t.rowId)}
+									type="button"
+									className={styles.deleteBtn}
+									aria-label="시간 삭제"
+									onClick={() => removeRow(t.rowId)}
 								>
-							    	<TiDelete className={styles.deleteIcon} />
+									<TiDelete className={styles.deleteIcon} />
 								</button>
 							</div>
 
 							<div className={styles.dayButtons}>
 								{DAYS.map((d) => {
-									const active = dayOfWeekToDay(t.dayOfweek) === d;
+									const dayOfweek = dayToDayOfWeek(d);
+									const active = t.dayOfweeks.includes(dayOfweek);
 									return (
 										<button
 											key={d}
 											type="button"
 											className={`${styles.dayBtn} ${active ? styles.isActive : ""}`}
-											onClick={() =>
-												updateRow(t.rowId, { dayOfweek: dayToDayOfWeek(d) })
-											}
+											aria-pressed={active}
+											onClick={() => toggleDay(t.rowId, dayOfweek)}
 										>
 											{DAY_LABELS_KO[d]}
 										</button>
@@ -262,6 +287,9 @@ export function AddClassPanel({
 
 					{!isTitleValid && (
 						<div className={styles.error}>과목 이름은 필수입니다.</div>
+					)}
+					{!hasSelectedDay && (
+						<div className={styles.error}>요일을 하나 이상 선택해주세요.</div>
 					)}
 					{hasConflict && (
 						<div className={styles.error}>시간이 겹치는 수업이 있습니다.</div>

--- a/src/pages/timetable/AddClassPanel.tsx
+++ b/src/pages/timetable/AddClassPanel.tsx
@@ -179,14 +179,21 @@ export function AddClassPanel({
 				</label>
 
 				<div>
-					<div>
+					<div className={styles.field}>
 						<div>시간 (필수)</div>
 					</div>
 
 					{slot.map((t) => (
 						<div key={t.rowId}>
 							<div className={styles.timeslotDelete}>
-								<TiDelete onClick={() => removeRow(t.rowId)} />
+								<button
+								type="button"
+								className={styles.deleteBtn}
+								aria-label="시간 삭제"
+								onClick={() => removeRow(t.rowId)}
+								>
+							    	<TiDelete className={styles.deleteIcon} />
+								</button>
 							</div>
 
 							<div className={styles.dayButtons}>

--- a/src/pages/timetable/TimeRangePicker.module.css
+++ b/src/pages/timetable/TimeRangePicker.module.css
@@ -1,0 +1,191 @@
+.rangePicker {
+	--selection-background: #f3f4f6;
+	--primary-text: #1f2329;
+	--secondary-text: #7b818a;
+	--accent: #1677ff;
+
+	width: min(100%, 720px);
+	box-sizing: border-box;
+	padding: 12px 0;
+	color: var(--primary-text);
+	background: transparent;
+	border: 0;
+	box-shadow: none;
+	font-family:
+		-apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Pretendard",
+		"Noto Sans KR", sans-serif;
+}
+
+.pickerSection {
+	min-width: 0;
+}
+
+.sectionHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 12px;
+	padding-inline: 8px;
+}
+
+.sectionLabel {
+	color: var(--secondary-text);
+	font-size: 14px;
+	font-weight: 650;
+	letter-spacing: -0.01em;
+}
+
+.timeOutput {
+	color: var(--accent);
+	font-size: 14px;
+	font-variant-numeric: tabular-nums;
+	font-weight: 700;
+}
+
+.timeWheel {
+	--wheel-height: calc(var(--item-height) * var(--visible-items));
+
+	position: relative;
+	display: grid;
+	grid-template-columns: 1.3fr 0.85fr 0.85fr;
+	min-width: 0;
+	height: var(--wheel-height);
+	margin: 0;
+	padding: 0;
+	overflow: hidden;
+	border: 0;
+	border-radius: 18px;
+	isolation: isolate;
+	-webkit-mask-image: linear-gradient(
+		to bottom,
+		transparent,
+		#000 28%,
+		#000 72%,
+		transparent
+	);
+	mask-image: linear-gradient(
+		to bottom,
+		transparent,
+		#000 28%,
+		#000 72%,
+		transparent
+	);
+}
+
+.selectionBand {
+	position: absolute;
+	z-index: -1;
+	top: 50%;
+	right: 0;
+	left: 0;
+	height: var(--item-height);
+	background: var(--selection-background);
+	border-radius: 14px;
+	transform: translateY(-50%);
+}
+
+.wheelColumn {
+	height: var(--wheel-height);
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	scrollbar-width: none;
+	scroll-snap-type: y mandatory;
+	touch-action: pan-y;
+	-webkit-overflow-scrolling: touch;
+}
+
+.wheelColumn::-webkit-scrollbar {
+	display: none;
+}
+
+.wheelColumn:focus-visible {
+	border-radius: 14px;
+	outline: 2px solid var(--accent);
+	outline-offset: -2px;
+}
+
+.wheelSpacer {
+	width: 100%;
+	scroll-snap-align: none;
+}
+
+.wheelItem {
+	display: flex;
+	width: 100%;
+	height: var(--item-height);
+	align-items: center;
+	justify-content: center;
+	padding: 0 8px;
+	color: var(--primary-text);
+	background: transparent;
+	border: 0;
+	font: inherit;
+	font-size: 16px;
+	font-variant-numeric: tabular-nums;
+	font-weight: 500;
+	line-height: 1;
+	opacity: 1;
+	scroll-snap-align: center;
+	scroll-snap-stop: always;
+	cursor: pointer;
+	transition:
+		opacity 140ms ease,
+		transform 140ms ease;
+}
+
+.wheelItem[data-distance="1"] {
+	opacity: 0.48;
+	transform: scale(0.9);
+}
+
+.wheelItem[data-distance="2"],
+.wheelItem[data-distance="3"] {
+	opacity: 0.18;
+	transform: scale(0.82);
+}
+
+.divider {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 42px;
+	color: var(--secondary-text);
+	font-size: 20px;
+}
+
+.divider span {
+	transform: rotate(90deg);
+}
+
+.error {
+	margin: 16px 8px 0;
+	color: #ff6961;
+	font-size: 13px;
+}
+
+@media (min-width: 680px) {
+	.rangePicker {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 40px minmax(0, 1fr);
+		align-items: center;
+	}
+
+	.divider {
+		height: auto;
+	}
+
+	.divider span {
+		transform: none;
+	}
+
+	.error {
+		grid-column: 1 / -1;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.wheelItem {
+		transition: none;
+	}
+}

--- a/src/pages/timetable/TimeRangePicker.module.css
+++ b/src/pages/timetable/TimeRangePicker.module.css
@@ -158,11 +158,6 @@
 	transform: rotate(90deg);
 }
 
-.error {
-	margin: 16px 8px 0;
-	color: #ff6961;
-	font-size: 13px;
-}
 
 @media (min-width: 680px) {
 	.rangePicker {
@@ -177,10 +172,6 @@
 
 	.divider span {
 		transform: none;
-	}
-
-	.error {
-		grid-column: 1 / -1;
 	}
 }
 

--- a/src/pages/timetable/TimeRangePicker.tsx
+++ b/src/pages/timetable/TimeRangePicker.tsx
@@ -1,0 +1,334 @@
+import {
+	type CSSProperties,
+	type KeyboardEvent,
+	type UIEvent,
+	useCallback,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+} from "react";
+import styles from "./TimeRangePicker.module.css";
+
+export type TimeValue = `${number}:${number}`;
+
+type Meridiem = "AM" | "PM";
+
+type WheelOption<T extends string | number> = {
+	value: T;
+	label: string;
+};
+
+type WheelColumnProps<T extends string | number> = {
+	ariaLabel: string;
+	options: WheelOption<T>[];
+	value: T;
+	onChange: (value: T) => void;
+};
+
+export type TimeWheelProps = {
+	value: TimeValue;
+	onChange: (value: TimeValue) => void;
+	minuteStep?: number;
+	ariaLabel?: string;
+};
+
+export type TimeRangePickerProps = {
+	startTime: TimeValue;
+	endTime: TimeValue;
+	onChange: (range: { startTime: TimeValue; endTime: TimeValue }) => void;
+	minuteStep?: number;
+	className?: string;
+};
+
+const ITEM_HEIGHT = 30;
+const VISIBLE_ITEMS = 5;
+const SCROLL_END_DELAY = 90;
+
+const pad = (value: number) => String(value).padStart(2, "0");
+
+function parseTime(value: TimeValue) {
+	const [rawHour, rawMinute] = value.split(":").map(Number);
+	const hour24 = Number.isFinite(rawHour)
+		? Math.min(23, Math.max(0, rawHour))
+		: 0;
+	const minute = Number.isFinite(rawMinute)
+		? Math.min(59, Math.max(0, rawMinute))
+		: 0;
+
+	return {
+		meridiem: (hour24 < 12 ? "AM" : "PM") as Meridiem,
+		hour12: hour24 % 12 || 12,
+		minute,
+	};
+}
+
+function toTimeValue(
+	meridiem: Meridiem,
+	hour12: number,
+	minute: number,
+): TimeValue {
+	const hour24 = meridiem === "AM" ? hour12 % 12 : (hour12 % 12) + 12;
+	return `${pad(hour24)}:${pad(minute)}` as TimeValue;
+}
+
+function timeToMinutes(value: TimeValue) {
+	const [hour, minute] = value.split(":").map(Number);
+	return hour * 60 + minute;
+}
+
+function WheelColumn<T extends string | number>({
+	ariaLabel,
+	options,
+	value,
+	onChange,
+}: WheelColumnProps<T>) {
+	const listRef = useRef<HTMLDivElement>(null);
+	const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const idPrefix = useId().replaceAll(":", "");
+	const selectedIndex = Math.max(
+		0,
+		options.findIndex((option) => option.value === value),
+	);
+
+	const scrollToIndex = useCallback(
+		(index: number, behavior: ScrollBehavior = "smooth") => {
+			const boundedIndex = Math.min(options.length - 1, Math.max(0, index));
+			listRef.current?.scrollTo({
+				top: boundedIndex * ITEM_HEIGHT,
+				behavior,
+			});
+		},
+		[options.length],
+	);
+
+	useEffect(() => {
+		scrollToIndex(selectedIndex, "auto");
+	}, [scrollToIndex, selectedIndex]);
+
+	useEffect(
+		() => () => {
+			if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+		},
+		[],
+	);
+
+	const commitNearestValue = (scrollTop: number) => {
+		const index = Math.min(
+			options.length - 1,
+			Math.max(0, Math.round(scrollTop / ITEM_HEIGHT)),
+		);
+		const nextValue = options[index].value;
+
+		if (nextValue !== value) onChange(nextValue);
+		scrollToIndex(index);
+	};
+
+	const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+		const scrollTop = event.currentTarget.scrollTop;
+
+		if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+		scrollTimerRef.current = setTimeout(
+			() => commitNearestValue(scrollTop),
+			SCROLL_END_DELAY,
+		);
+	};
+
+	const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		let nextIndex = selectedIndex;
+
+		if (event.key === "ArrowUp") nextIndex -= 1;
+		else if (event.key === "ArrowDown") nextIndex += 1;
+		else if (event.key === "Home") nextIndex = 0;
+		else if (event.key === "End") nextIndex = options.length - 1;
+		else return;
+
+		event.preventDefault();
+		nextIndex = Math.min(options.length - 1, Math.max(0, nextIndex));
+		onChange(options[nextIndex].value);
+		scrollToIndex(nextIndex);
+	};
+
+	return (
+		<div
+			ref={listRef}
+			className={styles.wheelColumn}
+			role="listbox"
+			aria-label={ariaLabel}
+			aria-activedescendant={`${idPrefix}-${String(value)}`}
+			tabIndex={0}
+			onScroll={handleScroll}
+			onKeyDown={handleKeyDown}
+		>
+			<div
+				className={styles.wheelSpacer}
+				style={{ height: ITEM_HEIGHT * Math.floor(VISIBLE_ITEMS / 2) }}
+				aria-hidden="true"
+			/>
+			{options.map((option, index) => {
+				const distance = Math.abs(index - selectedIndex);
+
+				return (
+					<button
+						id={`${idPrefix}-${String(option.value)}`}
+						key={String(option.value)}
+						type="button"
+						role="option"
+						aria-selected={option.value === value}
+						className={styles.wheelItem}
+						data-distance={Math.min(distance, 3)}
+						onClick={() => {
+							onChange(option.value);
+							scrollToIndex(index);
+						}}
+					>
+						{option.label}
+					</button>
+				);
+			})}
+			<div
+				className={styles.wheelSpacer}
+				style={{ height: ITEM_HEIGHT * Math.floor(VISIBLE_ITEMS / 2) }}
+				aria-hidden="true"
+			/>
+		</div>
+	);
+}
+
+export function TimeWheel({
+	value,
+	onChange,
+	minuteStep = 1,
+	ariaLabel = "시간",
+}: TimeWheelProps) {
+	const safeMinuteStep =
+		Number.isInteger(minuteStep) && minuteStep > 0 && minuteStep <= 30
+			? minuteStep
+			: 1;
+	const { meridiem, hour12, minute } = parseTime(value);
+	const lastMinute = Math.floor(59 / safeMinuteStep) * safeMinuteStep;
+	const minuteValue = Math.min(
+		lastMinute,
+		Math.round(minute / safeMinuteStep) * safeMinuteStep,
+	);
+
+	const meridiemOptions: WheelOption<Meridiem>[] = [
+		{ value: "AM", label: "오전" },
+		{ value: "PM", label: "오후" },
+	];
+	const hourOptions = useMemo(
+		() =>
+			Array.from({ length: 12 }, (_, index) => ({
+				value: index + 1,
+				label: String(index + 1),
+			})),
+		[],
+	);
+	const minuteOptions = useMemo(
+		() =>
+			Array.from(
+				{ length: Math.floor(59 / safeMinuteStep) + 1 },
+				(_, index) => {
+					const optionMinute = index * safeMinuteStep;
+					return { value: optionMinute, label: pad(optionMinute) };
+				},
+			),
+		[safeMinuteStep],
+	);
+
+	const update = (
+		nextMeridiem = meridiem,
+		nextHour = hour12,
+		nextMinute = minuteValue,
+	) => onChange(toTimeValue(nextMeridiem, nextHour, nextMinute));
+
+	return (
+		<fieldset
+			className={styles.timeWheel}
+			aria-label={ariaLabel}
+			style={
+				{
+					"--item-height": `${ITEM_HEIGHT}px`,
+					"--visible-items": VISIBLE_ITEMS,
+				} as CSSProperties
+			}
+		>
+			<div className={styles.selectionBand} aria-hidden="true" />
+			<WheelColumn
+				ariaLabel={`${ariaLabel} 오전 오후`}
+				options={meridiemOptions}
+				value={meridiem}
+				onChange={(next) => update(next)}
+			/>
+			<WheelColumn
+				ariaLabel={`${ariaLabel} 시`}
+				options={hourOptions}
+				value={hour12}
+				onChange={(next) => update(meridiem, next)}
+			/>
+			<WheelColumn
+				ariaLabel={`${ariaLabel} 분`}
+				options={minuteOptions}
+				value={minuteValue}
+				onChange={(next) => update(meridiem, hour12, next)}
+			/>
+		</fieldset>
+	);
+}
+
+export function TimeRangePicker({
+	startTime,
+	endTime,
+	onChange,
+	minuteStep = 1,
+	className,
+}: TimeRangePickerProps) {
+	const isInvalid = timeToMinutes(endTime) <= timeToMinutes(startTime);
+
+	return (
+		<section
+			className={[styles.rangePicker, className].filter(Boolean).join(" ")}
+			aria-label="수업 시간 설정"
+		>
+			<div className={styles.pickerSection}>
+				<div className={styles.sectionHeader}>
+					<span className={styles.sectionLabel}>시작 시간</span>
+					<output className={styles.timeOutput}>{startTime}</output>
+				</div>
+				<TimeWheel
+					value={startTime}
+					minuteStep={minuteStep}
+					ariaLabel="수업 시작 시간"
+					onChange={(nextStartTime) =>
+						onChange({ startTime: nextStartTime, endTime })
+					}
+				/>
+			</div>
+
+			<div className={styles.divider} aria-hidden="true">
+				<span>→</span>
+			</div>
+
+			<div className={styles.pickerSection}>
+				<div className={styles.sectionHeader}>
+					<span className={styles.sectionLabel}>종료 시간</span>
+					<output className={styles.timeOutput}>{endTime}</output>
+				</div>
+				<TimeWheel
+					value={endTime}
+					minuteStep={minuteStep}
+					ariaLabel="수업 종료 시간"
+					onChange={(nextEndTime) =>
+						onChange({ startTime, endTime: nextEndTime })
+					}
+				/>
+			</div>
+
+			{isInvalid && (
+				<p className={styles.error} role="alert">
+					종료 시간은 시작 시간보다 늦어야 합니다.
+				</p>
+			)}
+		</section>
+	);
+}

--- a/src/pages/timetable/TimeRangePicker.tsx
+++ b/src/pages/timetable/TimeRangePicker.tsx
@@ -283,7 +283,6 @@ export function TimeRangePicker({
 	minuteStep = 1,
 	className,
 }: TimeRangePickerProps) {
-	const isInvalid = timeToMinutes(endTime) <= timeToMinutes(startTime);
 
 	return (
 		<section
@@ -324,11 +323,6 @@ export function TimeRangePicker({
 				/>
 			</div>
 
-			{isInvalid && (
-				<p className={styles.error} role="alert">
-					종료 시간은 시작 시간보다 늦어야 합니다.
-				</p>
-			)}
 		</section>
 	);
 }

--- a/src/pages/timetable/TimeRangePicker.tsx
+++ b/src/pages/timetable/TimeRangePicker.tsx
@@ -72,11 +72,6 @@ function toTimeValue(
 	return `${pad(hour24)}:${pad(minute)}` as TimeValue;
 }
 
-function timeToMinutes(value: TimeValue) {
-	const [hour, minute] = value.split(":").map(Number);
-	return hour * 60 + minute;
-}
-
 function WheelColumn<T extends string | number>({
 	ariaLabel,
 	options,

--- a/src/pages/timetable/TimeSelect.module.css
+++ b/src/pages/timetable/TimeSelect.module.css
@@ -1,0 +1,80 @@
+.timeSelect {
+	position: relative;
+	flex: 1;
+	min-width: 0;
+}
+
+.trigger {
+	display: flex;
+	width: 100%;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 12px 8px 14px;
+	color: #1677ff;
+	background: #f2f2f2;
+	border: 0;
+	border-radius: 10px;
+	font: inherit;
+	font-size: 15px;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.trigger:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px rgb(22 119 255 / 25%);
+}
+
+.chevron {
+	width: 7px;
+	height: 7px;
+	color: #8a8f98;
+	border-right: 1.5px solid currentColor;
+	border-bottom: 1.5px solid currentColor;
+	transform: translateY(-2px) rotate(45deg);
+}
+
+.optionList {
+	position: absolute;
+	z-index: 20;
+	top: calc(100% + 6px);
+	right: 0;
+	left: 0;
+	max-height: 192px;
+	margin: 0;
+	padding: 5px;
+	overflow-y: auto;
+	background: #fff;
+	border: 1px solid #e6e6e6;
+	border-radius: 10px;
+	box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+	list-style: none;
+	overscroll-behavior: contain;
+	scrollbar-width: thin;
+}
+
+.option {
+	width: 100%;
+	padding: 8px 9px;
+	color: #333;
+	background: transparent;
+	border: 0;
+	border-radius: 7px;
+	font: inherit;
+	font-size: 14px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.option:hover,
+.option:focus-visible {
+	background: #f5f7fa;
+	outline: none;
+}
+
+.option.selectedOption {
+	color: #1677ff;
+	background: #eef5ff;
+	font-weight: 600;
+}

--- a/src/pages/timetable/TimeSelect.module.css
+++ b/src/pages/timetable/TimeSelect.module.css
@@ -16,7 +16,7 @@
 	border: 0;
 	border-radius: 10px;
 	font: inherit;
-	font-size: 15px;
+	font-size: 16px;
 	font-weight: 600;
 	cursor: pointer;
 }
@@ -62,7 +62,7 @@
 	border: 0;
 	border-radius: 7px;
 	font: inherit;
-	font-size: 14px;
+	font-size: 15px;
 	text-align: left;
 	cursor: pointer;
 }

--- a/src/pages/timetable/TimeSelect.tsx
+++ b/src/pages/timetable/TimeSelect.tsx
@@ -1,0 +1,160 @@
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
+import styles from "./TimeSelect.module.css";
+
+type TimeOption = {
+	value: number;
+	label: string;
+};
+
+type Props = {
+	ariaLabel: string;
+	value: number;
+	options: TimeOption[];
+	onChange: (value: number) => void;
+};
+
+export function TimeSelect({ ariaLabel, value, options, onChange }: Props) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [focusedIndex, setFocusedIndex] = useState(0);
+	const rootRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+	const listId = useId();
+	const selectedIndex = Math.max(
+		0,
+		options.findIndex((option) => option.value === value),
+	);
+	const selectedOption = options[selectedIndex];
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const handlePointerDown = (event: PointerEvent) => {
+			if (!rootRef.current?.contains(event.target as Node)) {
+				setIsOpen(false);
+			}
+		};
+
+		document.addEventListener("pointerdown", handlePointerDown);
+		return () => document.removeEventListener("pointerdown", handlePointerDown);
+	}, [isOpen]);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		requestAnimationFrame(() => {
+			optionRefs.current[focusedIndex]?.focus({ preventScroll: true });
+			optionRefs.current[focusedIndex]?.scrollIntoView({ block: "center" });
+		});
+	}, [focusedIndex, isOpen]);
+
+	const closeAndFocusTrigger = () => {
+		setIsOpen(false);
+		requestAnimationFrame(() => triggerRef.current?.focus());
+	};
+
+	const selectOption = (index: number) => {
+		const option = options[index];
+		if (!option) return;
+
+		onChange(option.value);
+		closeAndFocusTrigger();
+	};
+
+	const openAt = (index: number) => {
+		setFocusedIndex(index);
+		setIsOpen(true);
+	};
+
+	const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			openAt(Math.min(options.length - 1, selectedIndex + 1));
+		} else if (event.key === "ArrowUp") {
+			event.preventDefault();
+			openAt(Math.max(0, selectedIndex - 1));
+		}
+	};
+
+	const handleOptionKeyDown = (
+		event: KeyboardEvent<HTMLButtonElement>,
+		index: number,
+	) => {
+		let nextIndex = index;
+
+		if (event.key === "ArrowDown") {
+			nextIndex = Math.min(options.length - 1, index + 1);
+		} else if (event.key === "ArrowUp") {
+			nextIndex = Math.max(0, index - 1);
+		} else if (event.key === "Home") {
+			nextIndex = 0;
+		} else if (event.key === "End") {
+			nextIndex = options.length - 1;
+		} else if (event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			selectOption(index);
+			return;
+		} else if (event.key === "Escape" || event.key === "Tab") {
+			if (event.key === "Escape") event.preventDefault();
+			setIsOpen(false);
+			if (event.key === "Escape") {
+				requestAnimationFrame(() => triggerRef.current?.focus());
+			}
+			return;
+		} else {
+			return;
+		}
+
+		event.preventDefault();
+		setFocusedIndex(nextIndex);
+		optionRefs.current[nextIndex]?.focus();
+		optionRefs.current[nextIndex]?.scrollIntoView({ block: "nearest" });
+	};
+
+	return (
+		<div className={styles.timeSelect} ref={rootRef}>
+			<button
+				ref={triggerRef}
+				type="button"
+				className={styles.trigger}
+				aria-label={ariaLabel}
+				aria-haspopup="listbox"
+				aria-expanded={isOpen}
+				aria-controls={isOpen ? listId : undefined}
+				onClick={() => (isOpen ? setIsOpen(false) : openAt(selectedIndex))}
+				onKeyDown={handleTriggerKeyDown}
+			>
+				<span>{selectedOption?.label}</span>
+				<span className={styles.chevron} aria-hidden="true" />
+			</button>
+
+			{isOpen && (
+				<div id={listId} className={styles.optionList} role="listbox">
+					{options.map((option, index) => {
+						const isSelected = option.value === value;
+
+						return (
+							<button
+								key={option.value}
+								ref={(element) => {
+									optionRefs.current[index] = element;
+								}}
+								type="button"
+								role="option"
+								aria-selected={isSelected}
+								className={`${styles.option} ${
+									isSelected ? styles.selectedOption : ""
+								}`}
+								tabIndex={index === focusedIndex ? 0 : -1}
+								onClick={() => selectOption(index)}
+								onKeyDown={(event) => handleOptionKeyDown(event, index)}
+							>
+								{option.label}
+							</button>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/pages/timetable/Timetable.module.css
+++ b/src/pages/timetable/Timetable.module.css
@@ -119,8 +119,13 @@
 }
 
 .panel {
-  border-left: 1px solid #eee;
-  padding: 16px;
+	box-sizing: border-box;
+	min-height: 0;
+	height: 100vh;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	border-left: 1px solid #eee;
+	padding: 16px;
 }
 
 .addClassPanelDim {
@@ -558,6 +563,7 @@
     right: 0;
     bottom: calc(64px + env(safe-area-inset-bottom));
     z-index: 1200;
+    height: auto;
     max-height: min(72dvh, 620px);
     overflow-y: auto;
     padding: 18px 20px 22px;

--- a/src/pages/timetable/Timetable.module.css
+++ b/src/pages/timetable/Timetable.module.css
@@ -176,9 +176,9 @@
 }
 
 .timeRange {
-  display: flex;
-  gap: 10px;
-  align-items: center;
+	display: flex;
+	gap: 10px;
+	align-items: center;
 }
 
 .timeRange select {
@@ -603,20 +603,7 @@
     font-size: 12px;
   }
 
-  .timeRange {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-    gap: 8px;
-  }
-
-  .timeRange select {
-    width: 100%;
-    min-width: 0;
-    padding: 9px 10px;
-    font-size: 13px;
-  }
-
-  .gridWrap {
+	.gridWrap {
     width: 100%;
     min-width: 0;
     background: #ffffff;

--- a/src/pages/timetable/Timetable.module.css
+++ b/src/pages/timetable/Timetable.module.css
@@ -228,9 +228,22 @@
   justify-content: flex-end;
 }
 
+.deleteBtn {
+  display: lfex;
+  padding: 5px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.deleteIcon {
+  width: 24px;
+  height: 24px;
+  opacity: 0.4;
+}
 .error {
   margin-top: 8px;
-  font-size: 12px;
+  font-size: 14px;
   color: #d00;
 }
 
@@ -576,14 +589,14 @@
 
   .panel h2 {
     margin: 8px 0 18px;
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 700;
   }
 
   .field {
     gap: 8px;
     margin-bottom: 12px;
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 600;
   }
 
@@ -593,7 +606,7 @@
     width: 100%;
     padding: 11px 12px;
     border-radius: 8px;
-    font-size: 14px;
+    font-size: 16px;
   }
 
   .dayButtons {
@@ -606,7 +619,7 @@
     min-width: 0;
     padding: 7px 0;
     border-radius: 8px;
-    font-size: 12px;
+    font-size: 16px;
   }
 
 	.gridWrap {

--- a/src/pages/timetable/Timetable.module.css
+++ b/src/pages/timetable/Timetable.module.css
@@ -215,12 +215,26 @@
 }
 
 .link {
-  margin-top: 8px;
-  background: none;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  padding: 5px 10px;
   border: none;
-  color: #d00;
+  border-radius: 50px;
+  background: #aeaeae;
+  color: #ffffff;
   cursor: pointer;
-  padding: 0;
+  font-size: 16px;
+  font-weight: 400;
+  transition: background-color 0.15s ease;
+}
+
+.link:hover {
+  background: #737373;
+}
+
+.link:focus-visible {
+  outline: 2px solid #555555;
+  outline-offset: 2px;
 }
 
 .timeslotDelete {

--- a/src/pages/timetable/TimetablePage.tsx
+++ b/src/pages/timetable/TimetablePage.tsx
@@ -327,6 +327,7 @@ export default function TimetablePage() {
 					allSlots={allSlots}
 					year={year}
 					semester={semester}
+					isMobile={isMobile}
 					setIsClicked={setIsAddClassPanelOpen}
 				/>
 			)}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -171,6 +171,11 @@ export type TimeSlot = {
 	endAt: number;
 };
 
+export type MultiDaySlotRow = Omit<TimeSlot, "dayOfweek"> & {
+	rowId: string;
+	dayOfweeks: DayOfWeek[];
+};
+
 export type SlotRow = TimeSlot & { rowId: string };
 
 export const DAY_LABELS_KO: Record<Day, string> = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 모바일 버전 수업 시간 설정 UI 변경
<img width="295" height="585" alt="Screenshot 2026-07-29 020228" src="https://github.com/user-attachments/assets/8b004490-7e5a-46ad-8f1d-b65ca564974e" />

- 데스크탑 버전 수업 시간 설정 UI 디자인 변경
<img width="264" height="649" alt="Screenshot 2026-07-29 015212" src="https://github.com/user-attachments/assets/3639fe01-f1e2-402d-adfb-5931a2302ff4" />

- 시간표 타임 슬롯 삭제 버튼 사이즈 키움 (18px -> 24px)
<img width="596" height="674" alt="Screenshot 2026-07-31 223600" src="https://github.com/user-attachments/assets/99df7778-3c89-4b4e-8ff2-4939c31e0a69" />


- 데스크탑 버전 수업 추가 패널 스크롤 안되는 error 해결
- 추가할 수업의 시간대가 기존 수업과 겹칠 시, 에러 메시지 표시하도록 수정
> 이번 PR에서 작업한 내용
을 간략히 설명해주세요(이미지 첨부 가능)

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [x] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
