### PR TITLE
홈화면 이미지 레이아웃 수정

### DIFF
--- a/src/pages/auth/Home.module.css
+++ b/src/pages/auth/Home.module.css
@@ -29,7 +29,7 @@ body {
   min-height: 100dvh;
   height: auto;
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 0;
   background: #ffffff;
   overflow-x: clip;
@@ -37,19 +37,24 @@ body {
 }
 
 .visualPanel {
+  position: relative;
   flex: 1 1 64%;
   min-width: 0;
   min-height: 100vh;
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: center;
   background: #ffffff;
+  overflow: hidden;
 }
 
 .heroImage {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   object-fit: cover;
+  object-position: center center;
   display: block;
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#173 
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 홈화면 이미지 스크롤 영역 기준 높이 100%로 설정
- 가로 기준 가운데 정렬 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

https://github.com/user-attachments/assets/892ff213-643e-4512-8deb-c022a77a1424

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [x] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
