### PR TITLE
클라이언트 중복 참여형 행사 제거 처리

### DIFF
--- a/src/pages/calendar/CalendarView.tsx
+++ b/src/pages/calendar/CalendarView.tsx
@@ -28,6 +28,7 @@ import { useTimetable } from "@/contexts/TimetableContext";
 import { useMainPanelQuery } from "@/pages/calendar/hooks/useMainPanelQuery";
 import { useCalendarViewQuery } from "@/pages/calendar/hooks/useCalendarViewQuery";
 import { formatDateToYYYYMMDD } from "@/util/calendar/dateFormatter";
+import { filterEventTimeVariants } from "@/util/calendar/filterEventTimeVariants";
 
 const getSemesterByDate = (date: Date): Semester => {
 	const month = date.getMonth() + 1;
@@ -97,7 +98,6 @@ const CalendarView = () => {
 		interestCategories,
 	);
 
-
 	useEffect(() => {
 		const today = new Date();
 		void initializeDefaultOverlay(
@@ -121,7 +121,10 @@ const CalendarView = () => {
 		return Array.from(seen.values());
 	};
 
-	const MONTH_EVENTS = flattenByDate(monthViewData?.byDate);
+	const MONTH_EVENTS = filterEventTimeVariants(
+		flattenByDate(monthViewData?.byDate),
+		(event) => event,
+	);
 	const WEEK_EVENTS = flattenByDate(weekViewData?.byDate);
 
 	// Day context data doesn't need additional transformation; it is returned as Event[]
@@ -216,15 +219,15 @@ const CalendarView = () => {
 			<div className={styles.calendarContainer}>
 				<div className={styles.calendarWrapper}>
 					{isMobile ? (
-							<MyCalendar
-								monthEvents={MONTH_EVENTS}
-								weekEvents={WEEK_EVENTS}
-								dayEvents={dayViewEvents}
-								view={calendarView}
-								onShowMoreClick={onShowMoreClick}
-								onSelectEvent={onSelectEvent}
-								onViewChange={setCalendarView}
-							/>
+						<MyCalendar
+							monthEvents={MONTH_EVENTS}
+							weekEvents={WEEK_EVENTS}
+							dayEvents={dayViewEvents}
+							view={calendarView}
+							onShowMoreClick={onShowMoreClick}
+							onSelectEvent={onSelectEvent}
+							onViewChange={setCalendarView}
+						/>
 					) : (
 						<MyCalendar
 							monthEvents={MONTH_EVENTS}

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -20,6 +20,7 @@ import { useDetail } from "@/contexts/DetailContext";
 import { useAuth } from "@/contexts/AuthProvider";
 import { ProfileButton } from "@/components/layout/toolbar/Toolbar";
 import Modal from "@/components/ui/Modal";
+import { filterEventTimeVariants } from "@/util/calendar/filterEventTimeVariants";
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_GROUP_SIZE = 5;
@@ -50,15 +51,54 @@ const SearchView = () => {
 	useEffect(() => {
 		if (!query.trim()) {
 			setResult(null);
+			setLoading(false);
+			setError(false);
 			return;
 		}
-		setLoading(true);
-		setError(false);
-		getEventSearchFull({ query, page, size: pageSize })
-			.then(setResult)
-			.catch(() => setError(true))
-			.finally(() => setLoading(false));
-	}, [query, page, pageSize]);
+
+		let cancelled = false;
+		const fetchResults = async () => {
+			setLoading(true);
+			setError(false);
+			try {
+				const firstResult = await getEventSearchFull({
+					query,
+					page: 1,
+					size: DEFAULT_PAGE_SIZE,
+				});
+				const fullResult =
+					firstResult.items.length < firstResult.total
+						? await getEventSearchFull({
+								query,
+								page: 1,
+								size: firstResult.total,
+							})
+						: firstResult;
+				if (cancelled) return;
+
+				const items = filterEventTimeVariants(
+					fullResult.items,
+					(item) => item.event,
+				);
+				setResult({
+					...fullResult,
+					page: 1,
+					size: items.length,
+					total: items.length,
+					items,
+				});
+			} catch {
+				if (!cancelled) setError(true);
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		};
+
+		void fetchResults();
+		return () => {
+			cancelled = true;
+		};
+	}, [query]);
 
 	useEffect(() => {
 		function handleClickOutside(e: MouseEvent) {
@@ -82,6 +122,8 @@ const SearchView = () => {
 	};
 
 	const totalPages = result ? Math.ceil(result.total / pageSize) : 0;
+	const pageItems =
+		result?.items.slice((page - 1) * pageSize, page * pageSize) ?? [];
 	const currentGroupStart =
 		Math.floor((page - 1) / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1;
 	const currentGroupEnd = Math.min(
@@ -218,7 +260,7 @@ const SearchView = () => {
 						<div className={styles.resultCount}>총 {result.total}개 결과</div>
 						{viewMode === "list" ? (
 							<div className={styles.listContainer}>
-								{result.items.map((item) => (
+								{pageItems.map((item) => (
 									<SearchNewListItem
 										key={item.event.id}
 										item={item}
@@ -229,7 +271,7 @@ const SearchView = () => {
 							</div>
 						) : (
 							<div className={styles.gridContainer}>
-								{result.items.map((item) => (
+								{pageItems.map((item) => (
 									<SearchGridItem
 										key={item.event.id}
 										item={item}

--- a/src/util/calendar/filterEventTimeVariants.ts
+++ b/src/util/calendar/filterEventTimeVariants.ts
@@ -1,0 +1,92 @@
+import type { Event } from "@types";
+
+/**
+ * 의도 : 비교과 웹 크롤링 행사에서 참여형 행사가 여러 회차로 나뉘어져 있을때,
+ * 날짜를 더 정확하게 표시하기 위해 각 회차를 별개의 행사로 인식해서 표시하도록 되어 있음
+ * 그러나 동일한 날짜, 다른 시간대로 회차가 구분되는 경우, 월별 뷰와 검색 결과에서는 두 행사 모두 표시하는 것이 UI 상 중복 초래.
+ * (표시되는 UI 상 시간대만 다르고, 나머지 행사 제목 - 내용 - 신청 링크 모두 같으므로)
+ * 따라서 클라이언트에서 같은 제목 및 내용이 행사 && 같은 날짜 && 시간만 다름일때 월별뷰 / 검색 결과에서는 하나만 보이도록 필터링 진행.
+ */
+
+type EventRange = {
+	start: Date;
+	end: Date;
+};
+
+const normalizeRange = (
+	start: Date | null,
+	end: Date | null,
+): EventRange | null => {
+	const fallback = start ?? end;
+	if (!fallback) return null;
+
+	return {
+		start: start ?? fallback,
+		end: end ?? fallback,
+	};
+};
+
+const getDisplayedRange = (event: Event): EventRange | null => {
+	const eventRange = normalizeRange(event.eventStart, event.eventEnd);
+	const applyRange = normalizeRange(event.applyStart, event.applyEnd);
+
+	return event.isPeriodEvent
+		? (applyRange ?? eventRange)
+		: (eventRange ?? applyRange);
+};
+
+const getLocalDateKey = (date: Date) =>
+	`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+
+const getGroupKey = (event: Event, range: EventRange) => {
+	const contentIdentity = event.applyLink?.trim();
+	if (!contentIdentity) return null;
+
+	return JSON.stringify([
+		event.title.trim(),
+		contentIdentity,
+		getLocalDateKey(range.start),
+		getLocalDateKey(range.end),
+	]);
+};
+
+const getTimeKey = (range: EventRange) =>
+	`${range.start.getTime()}-${range.end.getTime()}`;
+
+
+export const filterEventTimeVariants = <T>(
+	items: T[],
+	getEvent: (item: T) => Event,
+): T[] => {
+	const itemMetadata = items.map((item) => {
+		const event = getEvent(item);
+		const range = getDisplayedRange(event);
+		if (!range) return { groupKey: null, timeKey: null };
+
+		return {
+			groupKey: getGroupKey(event, range),
+			timeKey: getTimeKey(range),
+		};
+	});
+
+	const timeKeysByGroup = new Map<string, Set<string>>();
+	for (const { groupKey, timeKey } of itemMetadata) {
+		if (!groupKey || !timeKey) continue;
+
+		const timeKeys = timeKeysByGroup.get(groupKey) ?? new Set<string>();
+		timeKeys.add(timeKey);
+		timeKeysByGroup.set(groupKey, timeKeys);
+	}
+
+	const keptVariantGroups = new Set<string>();
+	return items.filter((_, index) => {
+		const { groupKey } = itemMetadata[index];
+		if (!groupKey || (timeKeysByGroup.get(groupKey)?.size ?? 0) <= 1) {
+			return true;
+		}
+		if (keptVariantGroups.has(groupKey)) return false;
+
+		keptVariantGroups.add(groupKey);
+		return true;
+	});
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

#157 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

비교과 웹에서 참여형 행사 크롤링 시, 같은 행사 내 여러 회차가 존재하고, 회차별로 같은 날짜인데 시간만 다른 경우 월별 뷰 & 검색 결과에서는 해당 행사가 중복됨.
클라이언트에서 해당 경우를 체크하고 중복 시 제거.

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [ ] 테스트 통과 (또는 테스트 없음)
- [ ] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
