### PR TITLE
fix: show course details and delete button on mobile timetable

### DIFF
--- a/src/pages/timetable/Timetable.module.css
+++ b/src/pages/timetable/Timetable.module.css
@@ -393,19 +393,6 @@
   opacity: 0.85;
 }
 
-.simplifiedBlock {
-  background: #000000;
-  opacity: 0.15;
-  pointer-events: none;
-  z-index: 10;
-}
-
-.simplifiedBlock .blockRemove,
-.simplifiedBlock .blockTitle,
-.simplifiedBlock .blockTime {
-  display: none;
-}
-
 .eventBlock {
   position: absolute;
   box-sizing: border-box;
@@ -696,10 +683,6 @@
     border-radius: 0;
     font-size: 11px;
     line-height: 1.25;
-  }
-
-  .blockRemove {
-    display: none;
   }
 
   .blockTitle {

--- a/src/pages/timetable/TimetableGrid.tsx
+++ b/src/pages/timetable/TimetableGrid.tsx
@@ -160,7 +160,6 @@ export function TimetableGrid({
 							config={config}
 							// onSelectBlock={onSelectBlock}
 							onRemoveBlock={onRemoveBlock}
-							isSimplified={isSimplified}
 							eventBlocks={isSimplified ? eventBlocksByDay[d] : []}
 							onSelectEvent={onSelectEvent}
 						/>
@@ -178,7 +177,6 @@ function DayColumn<T>({
 	config,
 	onSelectBlock,
 	onRemoveBlock,
-	isSimplified,
 	eventBlocks,
 	onSelectEvent,
 }: {
@@ -188,7 +186,6 @@ function DayColumn<T>({
 	config: GridConfig;
 	onSelectBlock?: (id: number, item: T) => void;
 	onRemoveBlock?: (timetableId: number, enrollId: number) => Promise<void>;
-	isSimplified: boolean;
 	eventBlocks: LayoutedBlock[];
 	onSelectEvent?: (event: Event) => void;
 }) {
@@ -199,9 +196,7 @@ function DayColumn<T>({
 			{blocks.map((b) => (
 				<button
 					key={b.id}
-					className={`${styles.block} ${
-						isSimplified ? styles.simplifiedBlock : ""
-					}`}
+					className={styles.block}
 					style={{
 						top: b.top,
 						height: b.height,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
모바일 시간표 error 해결
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- 모바일에서 시간표 삭제 버튼
- 모바일에서 시간표 제목 + 시간대 등 수업 label 표시
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="571" height="821" alt="Screenshot 2026-08-08 152111" src="https://github.com/user-attachments/assets/a258991d-3b62-4c67-8477-1fffe913c924" />

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 테스트 통과 (또는 테스트 없음)
- [x] 브레이킹 체인지 여부 확인

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
